### PR TITLE
Fix Rotations for objects in negative space

### DIFF
--- a/Rain.Engine/GameWindow.cs
+++ b/Rain.Engine/GameWindow.cs
@@ -71,7 +71,7 @@ public class GameWindow : OpenTK.Windowing.Desktop.GameWindow
 		};
 
 		shaderProgram = new(shaderComponents);
-		perspective = new(new Angle { Degrees = 45.0f }, options.Width / options.Height, 0.1f, 100.0f);
+		perspective = new(new Angle { Degrees = 90.0f }, options.Width / options.Height, 0.1f, 100.0f);
 	}
 
 	protected override void OnResize(ResizeEventArgs e)
@@ -117,7 +117,7 @@ public class GameWindow : OpenTK.Windowing.Desktop.GameWindow
 
 		foreach (var model in ActiveScene.Models)
 		{
-			model.Rotate((float)(2.0f * args.Time), Axes.X, model.Location);
+			model.Rotate((float)(2.0f * args.Time), Axes.X);
 			//model.Translate(0, 0, (float)(-0.1f * args.Time));
 		}
 

--- a/Rain.Engine/Geometry/Rectangle.cs
+++ b/Rain.Engine/Geometry/Rectangle.cs
@@ -95,14 +95,14 @@ public class Rectangle : ITwoDimensional
 
 	public Vertex GetCenterVertex()
 	{
-		var greatestPointX = 0.0f;
-		var leastPointX = 0.0f;
+		var greatestPointX = Points[0].Vertex.X;
+		var leastPointX = Points[0].Vertex.X;
 
-		var greatestPointY = 0.0f;
-		var leastPointY = 0.0f;
+		var greatestPointY = Points[0].Vertex.Y;
+		var leastPointY = Points[0].Vertex.Y;
 
-		var greatestPointZ = 0.0f;
-		var leastPointZ = 0.0f;
+		var greatestPointZ = Points[0].Vertex.Z;
+		var leastPointZ = Points[0].Vertex.Z;
 
 		for (var point = 0; point < Points.Length; point++)
 		{

--- a/Rain.Engine/Geometry/TransformMatrix.cs
+++ b/Rain.Engine/Geometry/TransformMatrix.cs
@@ -9,6 +9,11 @@ namespace Rain.Engine.Geometry;
 
 public struct TransformMatrix
 {
+	public float this[int index0, int index1]
+	{
+		get => Matrix[index0, index1];
+		set => Matrix[index0, index1] = value;
+	}
 	/// <summary> The side size the matrix, every ITransformMatrix should be a Size * Size matrix. </summary>
 	public const int Size = 4;
 
@@ -69,14 +74,9 @@ public struct TransformMatrix
 		return new TransformMatrix(matrix, TransformType.Translation);
 	}
 
-	// In this state the method could be prone to "Gimbal Lock" (https://en.wikipedia.org/wiki/Gimbal_lock).
-	// Potentialy intensive computationaly as well.
-	// TODO: Look into this as potential solution (https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation).
-	// There's lots of scary math without numbers, yay... :)
-	// This could also be a useful resource: https://math.stackexchange.com/questions/8980/euler-angles-and-gimbal-lock
-	// I'm not a mathematition if you couldn't already tell.
-	//
-	// I have confirmed the gimble lock... damnit. Other than that this works.
+	public static TransformMatrix CreateTranslationMatrix(Vertex translation)
+		=> CreateTranslationMatrix(translation.X, translation.Y, translation.Z);
+
 	public static TransformMatrix CreateRotationMatrix(float angle, Axes axis)
 	{
 		var matrix = new float[Size, Size];
@@ -191,17 +191,15 @@ public struct TransformMatrix
 
 	public static Vertex operator *(TransformMatrix a, Vertex b)
 	{
-		var vertexArray = new float[Vertex.BufferSize];
-		vertexArray.Initialize();
+		var vertex = new float[]
+		{
+			(a.Matrix[0, 0] * b.X) + (a.Matrix[0, 1] * b.Y) + (a.Matrix[0, 2] * b.Z) + (a.Matrix[0, 3] * b.W),
+			(a.Matrix[1, 0] * b.X) + (a.Matrix[1, 1] * b.Y) + (a.Matrix[1, 2] * b.Z) + (a.Matrix[1, 3] * b.W),
+			(a.Matrix[2, 0] * b.X) + (a.Matrix[2, 1] * b.Y) + (a.Matrix[2, 2] * b.Z) + (a.Matrix[2, 3] * b.W),
+			(a.Matrix[3, 0] * b.X) + (a.Matrix[3, 1] * b.Y) + (a.Matrix[3, 2] * b.Z) + (a.Matrix[3, 3] * b.W),
+		};
 
-		for (var i = 0; i < vertexArray.Length; i++)
-			vertexArray[i] = 0;
-
-		for (var row = 0; row < Size; row++)
-			for (var collum = 0; collum < b.Array.Length; collum++)
-				vertexArray[row] += a.Matrix[row, collum] * b.Array[collum];
-
-		return new Vertex(vertexArray);
+		return new Vertex(vertex);
 	}
 
 	public static Vertex operator *(Vertex a, TransformMatrix b) => b * a;

--- a/Rain.Engine/Geometry/Triangle.cs
+++ b/Rain.Engine/Geometry/Triangle.cs
@@ -100,14 +100,14 @@ public class Triangle : ITwoDimensional
 
 	public Vertex GetCenterVertex()
 	{
-		var greatestPointX = 0.0f;
-		var leastPointX = 0.0f;
+		var greatestPointX = Points[0].Vertex.X;
+		var leastPointX = Points[0].Vertex.X;
 
-		var greatestPointY = 0.0f;
-		var leastPointY = 0.0f;
+		var greatestPointY = Points[0].Vertex.Y;
+		var leastPointY = Points[0].Vertex.Y;
 
-		var greatestPointZ = 0.0f;
-		var leastPointZ = 0.0f;
+		var greatestPointZ = Points[0].Vertex.Z;
+		var leastPointZ = Points[0].Vertex.Z;
 
 		for (var point = 0; point < Points.Length; point++)
 		{

--- a/Rain.Engine/Geometry/Vertex.cs
+++ b/Rain.Engine/Geometry/Vertex.cs
@@ -209,9 +209,34 @@ public struct Vertex : ISpacial, IEquatable<Vertex>
         return Equals(obj);
 	}
 
-	public static Vertex operator +(Vertex a, Vertex b) => new(a.X + b.X, a.Y + b.Y, a.Z + b.Z, a.W + b.W);
+	// Vertex to float scalaar operations.
+	public static Vertex operator +(Vertex a, float b) => new(a.X + b, a.Y + b, a.Z + b, 1.0f);
 
-	public static Vertex operator -(Vertex a, Vertex b) => new(a.X - b.X, a.Y - b.Y, a.Z - b.Z, a.W - b.W);
+	public static Vertex operator -(Vertex a, float b) => new(a.X - b, a.Y - b, a.Z - b, 1.0f);
+
+	public static Vertex operator *(Vertex a, float b) => new(a.X * b, a.Y * b, a.Z * b, 1.0f);
+
+	public static Vertex operator /(Vertex a, float b) => new(a.X / b, a.Y / b, a.Z / b, 1.0f);
+
+	// Vertex to double scalaar operations.
+	public static Vertex operator +(Vertex a, double b) 
+		=> new((float)(a.X + b), (float)(a.Y + b), (float)(a.Z + b), 1.0f);
+
+	public static Vertex operator -(Vertex a, double b) 
+		=> new((float)(a.X - b), (float)(a.Y - b), (float)(a.Z - b), 1.0f);
+
+	public static Vertex operator *(Vertex a, double b) 
+		=> new((float)(a.X * b), (float)(a.Y * b), (float)(a.Z * b), 1.0f);
+
+	public static Vertex operator /(Vertex a, double b) 
+		=> new((float)(a.X / b), (float)(a.Y / b), (float)(a.Z / b), 1.0f);
+
+	// Vertex to Vertex Vector style operations.
+	public static Vertex operator +(Vertex a, Vertex b) => new(a.X + b.X, a.Y + b.Y, a.Z + b.Z, 1.0f);
+
+	public static Vertex operator -(Vertex a, Vertex b) => new(a.X - b.X, a.Y - b.Y, a.Z - b.Z, 1.0f);
+
+	public static Vertex operator -(Vertex a) => new(-a.X, -a.Y, -a.Z, a.W);
 
 	public static Vertex operator *(Vertex a, Vertex b) 
 		=> CrossProduct(a, b);

--- a/Rain.Engine/Rendering/Solid.cs
+++ b/Rain.Engine/Rendering/Solid.cs
@@ -55,7 +55,7 @@ public class Solid : IRenderable, IEquatable<Solid>
 	public Vertex Location
 	{
 		get => GetCenterVertex();
-		set => Translate(value.X - Location.X, value.Y - Location.Y, value.Z - Location.Z);
+		set => Translate(value - Location);
 	}
 
 	public float LengthX
@@ -109,14 +109,14 @@ public class Solid : IRenderable, IEquatable<Solid>
 
 	public Vertex GetCenterVertex()
 	{
-		var greatestPointX = 0.0f;
-		var leastPointX = 0.0f;
+		var greatestPointX = Points[0].Vertex.X;
+		var leastPointX = Points[0].Vertex.X;
 
-		var greatestPointY = 0.0f;
-		var leastPointY = 0.0f;
+		var greatestPointY = Points[0].Vertex.Y;
+		var leastPointY = Points[0].Vertex.Y;
 
-		var greatestPointZ = 0.0f;
-		var leastPointZ = 0.0f;
+		var greatestPointZ = Points[0].Vertex.Z;
+		var leastPointZ = Points[0].Vertex.Z;
 
 		for (var point = 0; point < Points.Length; point++)
 		{
@@ -200,7 +200,7 @@ public class Solid : IRenderable, IEquatable<Solid>
 	public void Translate(Vertex vertex)
 		=> Translate(vertex.X, vertex.Y, vertex.Z);
 
-	public void Scale(float x, float y, float z)
+	public void Scale(float x = 1, float y = 1, float z = 1)
 	{
 		Points = (this * TransformMatrix.CreateScaleMatrix(x, y, z)).Points;
 		lengthX *= x;
@@ -221,13 +221,11 @@ public class Solid : IRenderable, IEquatable<Solid>
 
 	public void Rotate(float angle, Axes axis, Vertex vertex)
 	{
-		var center = GetCenterVertex();
-		var distance = vertex - center;
-		var rotationMatrix = TransformMatrix.CreateRotationMatrix(angle, axis);
+		var transform = TransformMatrix.CreateTranslationMatrix(vertex);
+		transform *= TransformMatrix.CreateRotationMatrix(angle, axis);
+		transform *= TransformMatrix.CreateTranslationMatrix(-vertex);
 
-		Translate(-(center.X + distance.X), -(center.Y + distance.Y), -(center.Z + distance.Z));
-		Points = (this * rotationMatrix).Points;
-		Translate(center.X + distance.X, center.Y + distance.Y, center.Z + distance.Z);
+		Points = (this * transform).Points;
 
 		switch(axis)
 		{

--- a/Rain.Game/Program.cs
+++ b/Rain.Game/Program.cs
@@ -37,7 +37,7 @@ class Program
 			Solid.SolidFromFace(rectangle3, new Texture[] { new("garfield.bmp") })
 		}; */
 
-		var cubeBase = new Rectangle(new(0.0f, 0.0f, -20.0f), 1.0f, 1.0f, new(203, 178, 238));
+		var cubeBase = new Rectangle(new(0.5f, 0.5f, -50.0f), 10.0f, 10.0f, new(203, 178, 238));
 		var textures = new Texture[] { new("interesting.bmp", 0.3f) };
 
 		var texturedBase = new TexturedFace()
@@ -54,7 +54,7 @@ class Program
 			new(textures)
 		};
 
-		var cube = Prism.MakePrism(texturedBase, cubeTextures, 1.0f);
+		var cube = Prism.MakePrism(texturedBase, cubeTextures, 10.0f);
 		var models = new IRenderable[] { cube };
 		var scene = new Scene(models);
 


### PR DESCRIPTION
Issues:
- Closes #23 
- Closes #20 

Adds an indexer to `TransfromMatrix` struct and fixes the `GetCenterVertex()` method in `Triangle`, `Rectangle`, and `Solid` which was the root cause of problems with `Rotate()` when objects had positions.