### PR TITLE
Replace reference type assignments with CopyTo() method for 3D objects

### DIFF
--- a/Rain.Engine/Geometry/ITwoDimensional.cs
+++ b/Rain.Engine/Geometry/ITwoDimensional.cs
@@ -56,6 +56,15 @@ public interface ITwoDimensional : ISpacial
 	/// A <c>Vertex</c> positioned at the center of the <c>ITwoDimensional</c>.
 	/// </returns>
 	public Vertex GetCenterVertex();
+
+	/// <summary>
+	/// Copies this <c>ITwoDimensional</c>'s data to another.
+	/// </summary>
+	/// 
+	/// <param name="twoDimensional">
+	/// The <c>ITwoDimensional</c> to copy data to.
+	/// </param>
+	public void CopyTo(out ITwoDimensional twoDimensional);
 	
 	/// <summary>
 	/// Translate the <c>ITwoDimensional</c> through three dimensional space.

--- a/Rain.Engine/Geometry/Point.cs
+++ b/Rain.Engine/Geometry/Point.cs
@@ -102,6 +102,13 @@ public class Point : IBufferable, ISpacial
 		TextureCoordinate = textureCoordinate;
 	}
 
+	private Point(Point point)
+	{
+		Vertex = new Vertex(point.Vertex.Array);
+		Color = new Color(point.Color.Array);
+		TextureCoordinate = new TextureCoordinate(point.TextureCoordinate.Array);
+	}
+
 	public double GetDistanceBetween(ISpacial other)
 		=> (Location - other.Location).Maginitude;
 
@@ -131,6 +138,16 @@ public class Point : IBufferable, ISpacial
 
 		return vertexData;
 	}
+
+	/// <summary>
+	/// Copies data from this <c>Point</c> to another.
+	/// </summary>
+	/// 
+	/// <param name="point">
+	/// The <c>Point</c> to copy data to.
+	/// </param>
+	public void CopyTo(out Point point)
+		=> point = new Point(this);
 
 	/// <summary> 
 	/// Tells OpenGL how to use the data sent through the Vertex Buffer. 

--- a/Rain.Engine/Geometry/Rectangle.cs
+++ b/Rain.Engine/Geometry/Rectangle.cs
@@ -3,6 +3,9 @@
 
 namespace Rain.Engine.Geometry;
 
+/// <summary>
+/// A class for creating and manipulating rectangles.
+/// </summary>
 public class Rectangle : ITwoDimensional
 {
 	private float rotationX = 0;
@@ -11,7 +14,7 @@ public class Rectangle : ITwoDimensional
 
 	private float rotationZ = 0;
 
-	public uint[] Elements => new uint[] { 0, 1, 2, 1, 3, 2 };
+	public uint[] Elements => new uint[] { 0, 1, 2, 0, 2, 3 };
 
 	public Point[] Points { get; private set; }
 
@@ -51,6 +54,13 @@ public class Rectangle : ITwoDimensional
 		set => Rotate(value / rotationZ, Axes.Z); 
 	}
 
+	/// <summary>
+	/// Creates a new <c>Rectangle</c> from an array of <c>Point</c> objects.
+	/// </summary>
+	/// 
+	/// <param name="points">
+	/// An array of <c>Point</c>s representing a rectangle.
+	/// </param>
 	public Rectangle(Point[] points)
 	{
 		if (points.Length != 4)
@@ -62,9 +72,25 @@ public class Rectangle : ITwoDimensional
 		if (points[1].GetDistanceBetween(points[2]) != points[3].GetDistanceBetween(points[0]))
 			throw new Exception($"{nameof(points)} does not make a Rectangle");
 
-		Points = points;
+		Points = new Point[points.Length];
+		points.CopyTo(Points, 0);
 	}
 
+	/// <summary>
+	/// Creates a new <c>Rectangle</c> from a desired location, height, and width.
+	/// </summary>
+	/// 
+	/// <param name="location">
+	/// The location of the <c>Rectangle</c>, this will be positioned at it's center.
+	/// </param>
+	/// 
+	/// <param name="width">
+	/// The <c>Rectangle</c>'s width.
+	/// </param>
+	/// 
+	/// <param name="height">
+	/// The <c>Rectangle</c>'s height.
+	/// </param>
 	public Rectangle(Vertex location, float width, float height)
 	{
 		var halfWidth = width / 2;
@@ -72,13 +98,32 @@ public class Rectangle : ITwoDimensional
 
 		Points = new Point[]
 		{
-			new(new(location.X - halfWidth, location.Y - halfHeight, location.Z), new(255, 255, 255), new(0.0f, 0.0f)),
-			new(new(location.X + halfWidth, location.Y - halfHeight, location.Z), new(255, 255, 255), new(1.0f, 0.0f)),
-			new(new(location.X - halfWidth, location.Y + halfHeight, location.Z), new(255, 255, 255), new(0.0f, 1.0f)),
-			new(new(location.X + halfWidth, location.Y + halfHeight, location.Z), new(255, 255, 255), new(1.0f, 1.0f))
+			new(new(location.X - halfWidth, location.Y - halfHeight, location.Z), new(255, 255, 255), new(1.0f, 0.0f)),
+			new(new(location.X + halfWidth, location.Y - halfHeight, location.Z), new(255, 255, 255), new(0.0f, 0.0f)),
+			new(new(location.X + halfWidth, location.Y + halfHeight, location.Z), new(255, 255, 255), new(0.0f, 1.0f)),
+			new(new(location.X - halfWidth, location.Y + halfHeight, location.Z), new(255, 255, 255), new(1.0f, 1.0f))
 		};
 	}
 
+	/// <summary>
+	/// Creates a new <c>Rectangle</c> from a desired location, height, width, and color.
+	/// </summary>
+	/// 
+	/// <param name="location">
+	/// The location of the <c>Rectangle</c>, this will be positioned at it's center.
+	/// </param>
+	/// 
+	/// <param name="width">
+	/// The <c>Rectangle</c>'s width.
+	/// </param>
+	/// 
+	/// <param name="height">
+	/// The <c>Rectangle</c>'s height.
+	/// </param>
+	/// 
+	/// <param name="color">
+	/// The <c>Rectangle</c>'s color.
+	/// </param>
 	public Rectangle(Vertex location, float width, float height, Color color)
 	{
 		var halfWidth = width / 2;
@@ -86,12 +131,27 @@ public class Rectangle : ITwoDimensional
 
 		Points = new Point[]
 		{
-			new(new(location.X - halfWidth, location.Y - halfHeight, location.Z), color, new(0.0f, 0.0f)),
-			new(new(location.X + halfWidth, location.Y - halfHeight, location.Z), color, new(1.0f, 0.0f)),
-			new(new(location.X - halfWidth, location.Y + halfHeight, location.Z), color, new(0.0f, 1.0f)),
-			new(new(location.X + halfWidth, location.Y + halfHeight, location.Z), color, new(1.0f, 1.0f))
+			new(new(location.X - halfWidth, location.Y - halfHeight, location.Z), color, new(1.0f, 0.0f)),
+			new(new(location.X + halfWidth, location.Y - halfHeight, location.Z), color, new(0.0f, 0.0f)),
+			new(new(location.X + halfWidth, location.Y + halfHeight, location.Z), color, new(0.0f, 1.0f)),
+			new(new(location.X - halfWidth, location.Y + halfHeight, location.Z), color, new(1.0f, 1.0f))
 		};
 	}
+
+	private Rectangle(Rectangle rectangle)
+	{
+		rotationX = rectangle.rotationX;
+		rotationY = rectangle.rotationY;
+		rotationZ = rectangle.rotationZ;
+
+		Points = new Point[rectangle.Points.Length];
+		
+		for (var point = 0; point < Points.Length; point++)
+			rectangle.Points[point].CopyTo(out Points[point]);
+	}
+
+	public double GetDistanceBetween(ISpacial other)
+		=> (Location - other.Location).Maginitude;
 
 	public Vertex GetCenterVertex()
 	{
@@ -129,8 +189,8 @@ public class Rectangle : ITwoDimensional
 		return new Vertex(midPointX, midPointY, midPointZ);
 	}
 
-	public double GetDistanceBetween(ISpacial other)
-		=> (Location - other.Location).Maginitude;
+	public void CopyTo(out ITwoDimensional twoDimensional)
+		=> twoDimensional = new Rectangle(this);
 
 	public void Translate(float x, float y, float z)
 		=> Points = (this * TransformMatrix.CreateTranslationMatrix(x, y, z)).Points;
@@ -140,9 +200,6 @@ public class Rectangle : ITwoDimensional
 
 	public void Scale(float x, float y)
 		=> Points = (this * TransformMatrix.CreateScaleMatrix(x, y, 1)).Points;
-
-	public void Scale(float x, float y, float z)
-		=> Points = (this * TransformMatrix.CreateScaleMatrix(x, y, z)).Points;
 
 	public void Rotate(float angle, Axes axis)
 		=> Rotate(angle, axis, Location);

--- a/Rain.Engine/Geometry/TextureCoordinate.cs
+++ b/Rain.Engine/Geometry/TextureCoordinate.cs
@@ -6,7 +6,7 @@ namespace Rain.Engine.Geometry;
 /// <summary> 
 /// Represents coordinates for texturing an object. 
 /// </summary>
-public class TextureCoordinate
+public struct TextureCoordinate
 {
 	/// <summary> 
 	/// The length of any array outputed by <c>TextureCoordinate.Array</c>. 
@@ -63,7 +63,7 @@ public class TextureCoordinate
 	public TextureCoordinate(float[] coordinateArray)
 	{
 		if (coordinateArray.Length != BufferSize)
-			throw new Exception($"{nameof(coordinateArray)} was not of correct length {BufferSize}");
+			throw new Exception($"{nameof(coordinateArray)} must be of length {BufferSize}");
 		
 		X = coordinateArray[0];
 		Y = coordinateArray[1];

--- a/Rain.Engine/Geometry/Triangle.cs
+++ b/Rain.Engine/Geometry/Triangle.cs
@@ -3,6 +3,9 @@
 
 namespace Rain.Engine.Geometry;
 
+/// <summary>
+/// A class for creating and manipulating triangles.
+/// </summary>
 public class Triangle : ISpacial, ITwoDimensional
 {
 	private float width;
@@ -66,13 +69,6 @@ public class Triangle : ISpacial, ITwoDimensional
 	{
 		if (points.Length != 3)
 			throw new Exception($"{nameof(points)} is not length 3 (Given length: {points.Length}).");
-
-		var pointSum = Angle.GetAngle(points[0], points[1], points[2]).Degrees;
-		pointSum += Angle.GetAngle(points[1], points[2], points[0]).Degrees;
-		pointSum += Angle.GetAngle(points[2], points[0], points[1]).Degrees;
-		
-		if (pointSum != 180)
-			throw new Exception($"{nameof(points)} does not make a Triangle");
 
 		Points = points;
 		width = (float)points[0].GetDistanceBetween(points[1]);
@@ -139,6 +135,22 @@ public class Triangle : ISpacial, ITwoDimensional
 		this.height = height;
 	}
 
+	private Triangle(Triangle triangle)
+	{
+		width = triangle.width;
+		height = triangle.height;
+
+		rotationX = triangle.rotationX;
+		rotationY = triangle.rotationY;
+		rotationZ = triangle.rotationZ;
+
+		Points = new Point[triangle.Points.Length];
+		triangle.Points.CopyTo(Points, 0);
+	}
+
+	public double GetDistanceBetween(ISpacial other)
+		=> (Location - other.Location).Maginitude;
+
 	public Vertex GetCenterVertex()
 	{
 		var greatestPointX = Points[0].Vertex.X;
@@ -175,11 +187,8 @@ public class Triangle : ISpacial, ITwoDimensional
 		return new Vertex(midPointX, midPointY, midPointZ);
 	}
 
-	public double GetDistanceBetween(ISpacial other)
-	{
-		var difference = Location - other.Location;
-		return Math.Sqrt(Math.Pow(difference.X, 2) + Math.Pow(difference.Y, 2) + Math.Pow(difference.Z, 2));
-	}
+	public void CopyTo(out ITwoDimensional triangle)
+		=> triangle = new Triangle(this);
 
 	public void Translate(float x, float y, float z)
 		=> Points = (this * TransformMatrix.CreateTranslationMatrix(x, y, z)).Points;

--- a/Rain.Engine/Geometry/Vertex.cs
+++ b/Rain.Engine/Geometry/Vertex.cs
@@ -118,6 +118,9 @@ public struct Vertex : ISpacial, IEquatable<Vertex>
 	/// </param>
 	public Vertex(float[] vertexArray)
 	{
+		if (vertexArray.Length != BufferSize)
+			throw new Exception($"{nameof(vertexArray)} must be of length {BufferSize}");
+		
 		X = vertexArray[0];
 		Y = vertexArray[1];
 		Z = vertexArray[2];

--- a/Rain.Engine/Rendering/Prism.cs
+++ b/Rain.Engine/Rendering/Prism.cs
@@ -28,7 +28,7 @@ public class Prism
 		shapeBase.Face.Rotate(-shapeBase.Face.RotationY, Axes.Y);
 		shapeBase.Face.Rotate(-shapeBase.Face.RotationZ, Axes.Z);
 
-		var basePrime = new TexturedFace(shapeBase);
+		shapeBase.CopyTo(out TexturedFace basePrime);
 		basePrime.Face.Translate(0, 0, lengthZ);
 
 		var faces = new TexturedFace[textures.Length + 2];
@@ -40,17 +40,21 @@ public class Prism
 		{
 			var adjacentPoint = point == shapeBase.Face.Points.Length - 1 ? 0 : point + 1;
 
-			var facePoints = new Point[]
-			{
-				shapeBase.Face.Points[point], shapeBase.Face.Points[adjacentPoint],
-				basePrime.Face.Points[point], basePrime.Face.Points[adjacentPoint]
-			};
+			var facePoints = new Point[4];
+			
+			shapeBase.Face.Points[point].CopyTo(out facePoints[0]);
+			facePoints[0].TextureCoordinate = new(0.0f, 0.0f);
 
-			var face = new TexturedFace()
-			{
-				Face = new Rectangle(facePoints),
-				Textures = textures[point].ToArray()
-			};
+			basePrime.Face.Points[point].CopyTo(out facePoints[1]);
+			facePoints[1].TextureCoordinate = new(0.0f, 1.0f);
+			
+			basePrime.Face.Points[adjacentPoint].CopyTo(out facePoints[2]);
+			facePoints[2].TextureCoordinate = new(1.0f, 1.0f);
+
+			shapeBase.Face.Points[adjacentPoint].CopyTo(out facePoints[3]);
+			facePoints[3].TextureCoordinate = new(1.0f, 0.0f);
+
+			var face = new TexturedFace(new Rectangle(facePoints), textures[point].ToArray());
 
 			faces[point + 2] = face;
 		}

--- a/Rain.Engine/Rendering/Pyramid.cs
+++ b/Rain.Engine/Rendering/Pyramid.cs
@@ -5,7 +5,7 @@ namespace Rain.Engine.Rendering;
 
 public class Pyramid
 {
-	public static IRenderable MakePyramid(TexturedFace shapeBase, EfficientTextureGroup[] textures, float lengthZ)
+	public static Solid MakePyramid(TexturedFace shapeBase, EfficientTextureGroup[] textures, float lengthZ)
 	{
 		if (textures.Length != shapeBase.Face.Sides)
 			throw new Exception($"{nameof(textures)} should be of length equal to {shapeBase.Face.Sides}");
@@ -33,23 +33,24 @@ public class Pyramid
 		faces[0] = shapeBase;
 
 		var translateUp = TransformMatrix.CreateTranslationMatrix(0, 0, lengthZ);
+		var tip = new Point(shapeBase.Face.Location * translateUp);
 
 		for (var point = 0; point < shapeBase.Face.Points.Length; point++)
 		{
-			var adjacentPoint = point == shapeBase.Face.Points.Length ? 0 : point + 1;
+			var adjacentPoint = point == shapeBase.Face.Points.Length - 1 ? 0 : point + 1;
 
-			var facePoints = new Point[]
-			{
-				shapeBase.Face.Points[point], 
-				shapeBase.Face.Points[adjacentPoint],
-				new Point(shapeBase.Face.GetCenterVertex() * translateUp)
-			};
+			var facePoints = new Point[3];
+			
+			shapeBase.Face.Points[point].CopyTo(out facePoints[0]);
+			facePoints[0].TextureCoordinate = new(1.0f, 0.0f);
 
-			var face = new TexturedFace()
-			{
-				Face = new Triangle(facePoints),
-				Textures = textures[point].ToArray()
-			};
+			tip.CopyTo(out facePoints[1]);
+			facePoints[1].TextureCoordinate = new(0.5f, 1.0f);
+			
+			shapeBase.Face.Points[adjacentPoint].CopyTo(out facePoints[2]);
+			facePoints[2].TextureCoordinate = new(0.0f, 0.0f);
+
+			var face = new TexturedFace(new Triangle(facePoints), textures[point].ToArray());
 
 			faces[point + 1] = face;
 		}

--- a/Rain.Engine/Rendering/Solid.cs
+++ b/Rain.Engine/Rendering/Solid.cs
@@ -109,45 +109,17 @@ public class Solid : IRenderable, IEquatable<Solid>
 
 	public Vertex GetCenterVertex()
 	{
-		var greatestPointX = Points[0].Vertex.X;
-		var leastPointX = Points[0].Vertex.X;
+		var averageVertex = Points[0].Vertex;
 
-		var greatestPointY = Points[0].Vertex.Y;
-		var leastPointY = Points[0].Vertex.Y;
-
-		var greatestPointZ = Points[0].Vertex.Z;
-		var leastPointZ = Points[0].Vertex.Z;
-
-		for (var point = 0; point < Points.Length; point++)
-		{
-			if (Points[point].Vertex.X > greatestPointX)
-				greatestPointX = Points[point].Vertex.X;
-			else if (Points[point].Vertex.X < leastPointX)
-				leastPointX = Points[point].Vertex.X;
-
-			if (Points[point].Vertex.Y > greatestPointY)
-				greatestPointY = Points[point].Vertex.Y;
-			else if (Points[point].Vertex.Y < leastPointY)
-				leastPointY = Points[point].Vertex.Y;
-
-			if (Points[point].Vertex.Z > greatestPointZ)
-				greatestPointZ = Points[point].Vertex.Z;
-			else if (Points[point].Vertex.Z < leastPointZ)
-				leastPointZ = Points[point].Vertex.Z;
-		}
-
-		var midPointX = (greatestPointX + leastPointX) / 2;
-		var midPointY = (greatestPointY + leastPointY) / 2;
-		var midPointZ = (greatestPointZ + leastPointZ) / 2;
-
-		return new Vertex(midPointX, midPointY, midPointZ);
+		for (var point = 1; point < Points.Length; point++)
+			averageVertex += Points[point].Vertex;
+		
+		averageVertex /= Points.Length;
+		return averageVertex;
 	}
 
 	public double GetDistanceBetween(ISpacial other)
-	{
-		var difference = Location - other.Location;
-		return Math.Sqrt(Math.Pow(difference.X, 2) + Math.Pow(difference.Y, 2) + Math.Pow(difference.Z, 2));
-	}
+		=> (Location - other.Location).Maginitude;
 
 	public Array GetBufferableArray(BufferType bufferType)
 	{
@@ -255,11 +227,7 @@ public class Solid : IRenderable, IEquatable<Solid>
 	{
 		var textureFaces = new TexturedFace[] 
 		{
-			new TexturedFace 
-			{ 
-				Face = twoDimensional, 
-				Textures = textures
-			}
+			new TexturedFace(twoDimensional, textures)
 		};
 
 		var options = new SolidOptions 

--- a/Rain.Engine/Texturing/Texture.cs
+++ b/Rain.Engine/Texturing/Texture.cs
@@ -70,12 +70,12 @@ public class Texture : IDisposable
 	/// <summary>
 	/// The image's width.
 	/// </summary>
-	public int Width { get; }
+	public int Width { get; private set; }
 
 	/// <summary>
 	/// The images height.
 	/// </summary>
-	public int Height { get; }
+	public int Height { get; private set; }
 
 	/// <summary>
 	/// The opacity the <c>Texture</c> will be rendered at.
@@ -254,6 +254,26 @@ public class Texture : IDisposable
 		this.options = options;
 	}
 
+	private Texture(Texture texture)
+	{
+		options = texture.options;
+		Handle = texture.Handle;
+		Unit = texture.Unit;
+
+		Width = texture.Width;
+		Height = texture.Height;
+		Opacity = texture.Opacity;
+
+		IsEmpty = texture.IsEmpty;
+		IsUploaded = texture.IsUploaded;
+
+		// Allocates new memory so that changed made to the new texture dont affect the previous.
+		textureMemoryOwner = Configuration.Default.MemoryAllocator.Allocate<Rgba32>(Width * Height);
+		textureMemory = textureMemoryOwner.Memory;
+
+		texture.textureMemory.CopyTo(textureMemory);
+	}
+
 	/// <summary>
 	/// Uploads this <c>Texture</c> to the GPU.
 	/// </summary>
@@ -336,6 +356,16 @@ public class Texture : IDisposable
 
 		Handle = GL.GenTexture();
 	}
+
+	/// <summary>
+	/// Copies this <c>Texture</c>'s data to another.
+	/// </summary>
+	/// 
+	/// <param name="texture">
+	/// The <c>Texture</c> to copy data to.
+	/// </param>
+	public void CopyTo(out Texture texture)
+		=> texture = new(this);
 
 	public override int GetHashCode()
 		=> textureMemory.GetHashCode();


### PR DESCRIPTION
Issues:
- Closes #19 

Only one face would be rendered because the face would be copied, but as a reference type changes to one affected the other, making a prism with length 0 along the Z axis, and two faces stacked directly on top of each other.