### PR TITLE
Length property setters in respect to rotation

### DIFF
--- a/Rain.Engine.Tests/Rendering/PrismTests.cs
+++ b/Rain.Engine.Tests/Rendering/PrismTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) 2022 Evan Overman (https://an-prata.it). Licensed under the MIT License.
+// See LICENSE file in repository root for complete license text.
+
+using Xunit;
+using Rain.Engine.Geometry;
+using Rain.Engine.Rendering;
+using Rain.Engine.Texturing;
+
+namespace Rain.Engine.Tests;
+
+public class PrismTests
+{
+	[Theory]
+	[InlineData(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f)]
+	[InlineData(10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 892.0f, 90.0f)]
+	[InlineData(250.0f, 10.0f, 0.0f, 50.0f, 10.0f, 11.0f, 0.0f, 0.0f)]
+	// Just because this test passes does not mean the Prism has been constructed correctly, the same values should be put in
+	// a project and rendered on an actual window to confirm that the geometry has been rendered correcly.
+	public void ConstructorTest(float x, float y, float z, float lengthX, float lengthY, float lengthZ, float angleX, float angleY)
+	{
+		var textures = new Texture[] { new Texture() };
+
+		var textureGroups = new EfficientTextureGroup[] 
+		{ 
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures)
+		};
+
+		var face = new Rectangle(new Vertex(x, y, z), lengthX, lengthY);
+
+		face.Rotate(angleX, Axes.X);
+		face.Rotate(angleY, Axes.Y);
+
+		var shapeBase = new TexturedFace(face, textures);
+		var prism = new Prism(shapeBase, textureGroups, lengthZ);
+
+		Assert.Equal(lengthX, prism.LengthX);
+		Assert.Equal(lengthY, prism.LengthY);
+		Assert.Equal(lengthY, prism.LengthY);
+
+		Assert.Equal(angleX, prism.RotationX);
+		Assert.Equal(angleY, prism.RotationY);
+	}
+
+	[Theory]
+	[InlineData(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f)]
+	[InlineData(10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 892.0f, 90.0f, 0.0f)]
+	[InlineData(250.0f, 10.0f, 0.0f, 50.0f, 10.0f, 11.0f, 0.0f, 0.0f, 900.0f)]
+	public void ScalingTest(float x, float y, float z, float lengthX, float lengthY, float lengthZ, float scaleX, float scaleY, float scaleZ)
+	{
+		var textures = new Texture[] { new Texture() };
+
+		var textureGroups = new EfficientTextureGroup[] 
+		{ 
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures)
+		};
+
+		var face = new Rectangle(new Vertex(x, y, z), lengthX, lengthY);
+		var shapeBase = new TexturedFace(face, textures);
+		var prism = new Prism(shapeBase, textureGroups, lengthZ);
+
+		prism.Scale(scaleX, scaleY, scaleZ);
+
+		Assert.Equal(scaleX * lengthX, prism.LengthX);
+		Assert.Equal(scaleY * lengthY, prism.LengthY);
+		Assert.Equal(scaleZ * lengthZ, prism.LengthZ);
+	}
+
+	[Theory]
+	[InlineData(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f)]
+	[InlineData(10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 892.0f, 90.0f, 0.0f)]
+	[InlineData(250.0f, 10.0f, 0.0f, 50.0f, 10.0f, 11.0f, 0.0f, 0.0f, 900.0f)]
+	public void RotationTest(float x, float y, float z, float lengthX, float lengthY, float lengthZ, float angleX, float angleY, float angleZ)
+	{
+		var textures = new Texture[] { new Texture() };
+
+		var textureGroups = new EfficientTextureGroup[] 
+		{ 
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures)
+		};
+
+		var face = new Rectangle(new Vertex(x, y, z), lengthX, lengthY);
+		var shapeBase = new TexturedFace(face, textures);
+		var prism = new Prism(shapeBase, textureGroups, lengthZ);
+
+		prism.Rotate(angleX, Axes.X);
+		prism.Rotate(angleY, Axes.Y);
+		prism.Rotate(angleZ, Axes.Z);
+
+		Assert.Equal(angleX, prism.RotationX);
+		Assert.Equal(angleY, prism.RotationY);
+		Assert.Equal(angleY, prism.RotationY);
+	}
+}

--- a/Rain.Engine.Tests/Rendering/PyramidTests.cs
+++ b/Rain.Engine.Tests/Rendering/PyramidTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) 2022 Evan Overman (https://an-prata.it). Licensed under the MIT License.
+// See LICENSE file in repository root for complete license text.
+
+using Xunit;
+using Rain.Engine.Geometry;
+using Rain.Engine.Rendering;
+using Rain.Engine.Texturing;
+
+namespace Rain.Engine.Tests;
+
+public class PyramidTests
+{
+	[Theory]
+	[InlineData(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f)]
+	[InlineData(10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 892.0f, 90.0f)]
+	[InlineData(250.0f, 10.0f, 0.0f, 50.0f, 10.0f, 11.0f, 0.0f, 0.0f)]
+	// Just because this test passes does not mean the Pyramid has been constructed correctly, the same values should be put in
+	// a project and rendered on an actual window to confirm that the geometry has been rendered correcly.
+	public void ConstructorTest(float x, float y, float z, float lengthX, float lengthY, float lengthZ, float angleX, float angleY)
+	{
+		var textures = new Texture[] { new Texture() };
+
+		var textureGroups = new EfficientTextureGroup[] 
+		{ 
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures)
+		};
+
+		var face = new Rectangle(new Vertex(x, y, z), lengthX, lengthY);
+
+		face.Rotate(angleX, Axes.X);
+		face.Rotate(angleY, Axes.Y);
+
+		var shapeBase = new TexturedFace(face, textures);
+		var pyramid = new Pyramid(shapeBase, textureGroups, lengthZ);
+
+		Assert.Equal(lengthX, pyramid.LengthX);
+		Assert.Equal(lengthY, pyramid.LengthY);
+		Assert.Equal(lengthY, pyramid.LengthY);
+
+		Assert.Equal(angleX, pyramid.RotationX);
+		Assert.Equal(angleY, pyramid.RotationY);
+	}
+
+	[Theory]
+	[InlineData(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f)]
+	[InlineData(10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 892.0f, 90.0f, 0.0f)]
+	[InlineData(250.0f, 10.0f, 0.0f, 50.0f, 10.0f, 11.0f, 0.0f, 0.0f, 900.0f)]
+	public void ScalingTest(float x, float y, float z, float lengthX, float lengthY, float lengthZ, float scaleX, float scaleY, float scaleZ)
+	{
+		var textures = new Texture[] { new Texture() };
+
+		var textureGroups = new EfficientTextureGroup[] 
+		{ 
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures)
+		};
+
+		var face = new Rectangle(new Vertex(x, y, z), lengthX, lengthY);
+		var shapeBase = new TexturedFace(face, textures);
+		var pyramid = new Pyramid(shapeBase, textureGroups, lengthZ);
+
+		pyramid.Scale(scaleX, scaleY, scaleZ);
+
+		Assert.Equal(scaleX * lengthX, pyramid.LengthX);
+		Assert.Equal(scaleY * lengthY, pyramid.LengthY);
+		Assert.Equal(scaleZ * lengthZ, pyramid.LengthZ);
+	}
+
+	[Theory]
+	[InlineData(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f)]
+	[InlineData(10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 892.0f, 90.0f, 0.0f)]
+	[InlineData(250.0f, 10.0f, 0.0f, 50.0f, 10.0f, 11.0f, 0.0f, 0.0f, 900.0f)]
+	public void RotationTest(float x, float y, float z, float lengthX, float lengthY, float lengthZ, float angleX, float angleY, float angleZ)
+	{
+		var textures = new Texture[] { new Texture() };
+
+		var textureGroups = new EfficientTextureGroup[] 
+		{ 
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures)
+		};
+
+		var face = new Rectangle(new Vertex(x, y, z), lengthX, lengthY);
+		var shapeBase = new TexturedFace(face, textures);
+		var pyramid = new Pyramid(shapeBase, textureGroups, lengthZ);
+
+		pyramid.Rotate(angleX, Axes.X);
+		pyramid.Rotate(angleY, Axes.Y);
+		pyramid.Rotate(angleZ, Axes.Z);
+
+		Assert.Equal(angleX, pyramid.RotationX);
+		Assert.Equal(angleY, pyramid.RotationY);
+		Assert.Equal(angleY, pyramid.RotationY);
+	}
+}

--- a/Rain.Engine/GameWindow.cs
+++ b/Rain.Engine/GameWindow.cs
@@ -112,7 +112,7 @@ public class GameWindow : OpenTK.Windowing.Desktop.GameWindow
 	{
 		foreach (var model in ActiveScene.Models)
 		{
-			model.LengthY -= (float)(1.0f * args.Time);
+			//model.LengthY -= (float)(1.0f * args.Time);
 			//model.Rotate((float)(2.0f * args.Time), Axes.X);
 			model.Rotate((float)(2.0f * args.Time), Axes.Y);
 			//model.Translate(0, 0, (float)(-0.1f * args.Time));

--- a/Rain.Engine/GameWindow.cs
+++ b/Rain.Engine/GameWindow.cs
@@ -112,8 +112,9 @@ public class GameWindow : OpenTK.Windowing.Desktop.GameWindow
 	{
 		foreach (var model in ActiveScene.Models)
 		{
-			model.Rotate((float)(6.0f * args.Time), Axes.X);
-			model.Rotate((float)(6.0f * args.Time), Axes.Y);
+			model.LengthY -= (float)(1.0f * args.Time);
+			//model.Rotate((float)(2.0f * args.Time), Axes.X);
+			model.Rotate((float)(2.0f * args.Time), Axes.Y);
 			//model.Translate(0, 0, (float)(-0.1f * args.Time));
 		}
 		

--- a/Rain.Engine/Geometry/IModel.cs
+++ b/Rain.Engine/Geometry/IModel.cs
@@ -18,17 +18,17 @@ public interface IModel : ISpacial
 	/// <summary> 
 	/// The length of the <c>IModel</c> along the X axis. 
 	/// </summary>
-	float LengthX { get; }
+	float LengthX { get; set; }
 
 	/// <summary> 
 	/// The length of the <c>IModel</c> along the Y axis. 
 	/// </summary>
-	float LengthY { get; }
+	float LengthY { get; set; }
 
 	/// <summary> 
 	/// The length of the <c>IModel</c> along the Z axis. 
 	/// </summary>
-	float LengthZ { get; }
+	float LengthZ { get; set; }
 
 	/// <summary>
 	/// The <c>IModel</c>'s counter-clockwise rotation on the X axis.

--- a/Rain.Engine/Geometry/Rectangle.cs
+++ b/Rain.Engine/Geometry/Rectangle.cs
@@ -32,7 +32,7 @@ public class Rectangle : ITwoDimensional
 
 	public float Height 
 	{ 
-		get => (float)Points[0].GetDistanceBetween(Points[2]);
+		get => (float)Points[0].GetDistanceBetween(Points[3]);
 		set => Scale(1, value / Height); 
 	}
 

--- a/Rain.Engine/Rendering/Prism.cs
+++ b/Rain.Engine/Rendering/Prism.cs
@@ -50,7 +50,6 @@ public class Prism : RenderableBase
 		for (var point = 0; point < shapeBase.Face.Points.Length; point++)
 		{
 			var adjacentPoint = point == shapeBase.Face.Points.Length - 1 ? 0 : point + 1;
-
 			var facePoints = new Point[4];
 			
 			shapeBase.Face.Points[point].CopyTo(out facePoints[0]);
@@ -70,10 +69,13 @@ public class Prism : RenderableBase
 			faces[point + 2] = face;
 		}
 
-		Faces = new(faces);
+		foreach (var face in faces)
+		{
+			face.Face.Rotate(rotateBackX, Axes.X, shapeBase.Face.Location);
+			face.Face.Rotate(rotateBackY, Axes.Y, shapeBase.Face.Location);
+			face.Face.Rotate(rotateBackZ, Axes.Z, shapeBase.Face.Location);
+		}
 
-		Rotate(rotateBackX, Axes.X);
-		Rotate(rotateBackY, Axes.Y);
-		Rotate(rotateBackZ, Axes.Z);
+		Faces = new(faces);
 	}
 }

--- a/Rain.Engine/Rendering/Prism.cs
+++ b/Rain.Engine/Rendering/Prism.cs
@@ -25,7 +25,8 @@ public class Prism : RenderableBase
 	/// <param name="lengthZ">
 	/// The length along the Z axis for this <c>Prism</c>.
 	/// </param>
-	public Prism(TexturedFace shapeBase, EfficientTextureGroup[] textures, float lengthZ)
+	public Prism(TexturedFace shapeBase, EfficientTextureGroup[] textures, float lengthZ) :
+		base(shapeBase.Face.Width, shapeBase.Face.Height, lengthZ, shapeBase.Face.RotationX, shapeBase.Face.RotationY, shapeBase.Face.RotationZ)
 	{
 		if (textures.Length != shapeBase.Face.Sides)
 			throw new Exception($"{nameof(textures)} should be of length equal to {shapeBase.Face.Sides}");

--- a/Rain.Engine/Rendering/Pyramid.cs
+++ b/Rain.Engine/Rendering/Pyramid.cs
@@ -25,7 +25,8 @@ public class Pyramid : RenderableBase
 	/// <param name="lengthZ">
 	/// The length along the Z axis for this <c>Pyramid</c>.
 	/// </param>
-	public Pyramid(TexturedFace shapeBase, EfficientTextureGroup[] textures, float lengthZ)
+	public Pyramid(TexturedFace shapeBase, EfficientTextureGroup[] textures, float lengthZ) :
+		base(shapeBase.Face.Width, shapeBase.Face.Height, lengthZ, shapeBase.Face.RotationX, shapeBase.Face.RotationY, shapeBase.Face.RotationZ)
 	{
 		if (textures.Length != shapeBase.Face.Sides)
 			throw new Exception($"{nameof(textures)} should be of length equal to {shapeBase.Face.Sides}");

--- a/Rain.Engine/Rendering/Pyramid.cs
+++ b/Rain.Engine/Rendering/Pyramid.cs
@@ -49,7 +49,6 @@ public class Pyramid : RenderableBase
 		for (var point = 0; point < shapeBase.Face.Points.Length; point++)
 		{
 			var adjacentPoint = point == shapeBase.Face.Points.Length - 1 ? 0 : point + 1;
-
 			var facePoints = new Point[3];
 			
 			shapeBase.Face.Points[point].CopyTo(out facePoints[0]);
@@ -66,10 +65,13 @@ public class Pyramid : RenderableBase
 			faces[point + 1] = face;
 		}
 
-		Faces = new(faces);
+		foreach (var face in faces)
+		{
+			face.Face.Rotate(rotateBackX, Axes.X, shapeBase.Face.Location);
+			face.Face.Rotate(rotateBackY, Axes.Y, shapeBase.Face.Location);
+			face.Face.Rotate(rotateBackZ, Axes.Z, shapeBase.Face.Location);
+		}
 
-		Rotate(rotateBackX, Axes.X);
-		Rotate(rotateBackY, Axes.Y);
-		Rotate(rotateBackZ, Axes.Z);
+		Faces = new(faces);
 	}
 }

--- a/Rain.Engine/Rendering/RenderableBase.cs
+++ b/Rain.Engine/Rendering/RenderableBase.cs
@@ -12,17 +12,17 @@ namespace Rain.Engine.Rendering;
 /// </summary>
 public abstract class RenderableBase : IRenderable, IEquatable<RenderableBase>
 {
-	private float lengthX;
+	private float lengthX = 1.0f;
 
-	private float lengthY;
+	private float lengthY = 1.0f;
 
-	private float lengthZ;
+	private float lengthZ = 1.0f;
 
-	private float rotationX = 0;
+	private float rotationX = 0.0f;
 
-	private float rotationY = 0;
+	private float rotationY = 0.0f;
 
-	private float rotationZ = 0;
+	private float rotationZ = 0.0f;
 
 	/// <summary>
 	/// The <c>TexturedFace</c> objects this object is composed of.
@@ -100,6 +100,17 @@ public abstract class RenderableBase : IRenderable, IEquatable<RenderableBase>
 		set => Rotate(value / rotationZ, Axes.Z); 
 	}
 
+	public RenderableBase(float lengthX, float lengthY, float lengthZ, float rotationX, float rotationY, float rotationZ)
+	{
+		this.lengthX = lengthX;
+		this.lengthY = lengthY;
+		this.lengthZ = lengthZ;
+
+		this.rotationX = rotationX;
+		this.rotationY = rotationY;
+		this.rotationZ = rotationZ;
+	}
+
 	public Vertex GetCenterVertex()
 	{
 		var averageVertex = Points[0].Vertex;
@@ -167,23 +178,25 @@ public abstract class RenderableBase : IRenderable, IEquatable<RenderableBase>
 
 	public void Scale(float x = 1, float y = 1, float z = 1)
 	{
-		var transform = TransformMatrix.CreateScaleMatrix(x, y, z);
+		var transform = TransformMatrix.CreateTranslationMatrix(Location);
 
 		transform *= TransformMatrix.CreateRotationMatrix(-rotationX, Axes.X);
 		transform *= TransformMatrix.CreateRotationMatrix(-rotationY, Axes.Y);
 		transform *= TransformMatrix.CreateRotationMatrix(-rotationZ, Axes.Z);
+
+		transform *= TransformMatrix.CreateScaleMatrix(x, y, z);
+
+		transform *= TransformMatrix.CreateRotationMatrix(rotationX, Axes.X);
+		transform *= TransformMatrix.CreateRotationMatrix(rotationY, Axes.Y);
+		transform *= TransformMatrix.CreateRotationMatrix(rotationZ, Axes.Z);
+		
+		transform *= TransformMatrix.CreateTranslationMatrix(-Location);
 
 		Points = (this * transform).Points;
 
 		lengthX *= x;
 		lengthY *= y;
 		lengthZ *= z;
-
-		transform = TransformMatrix.CreateRotationMatrix(rotationX, Axes.X) 
-				  * TransformMatrix.CreateRotationMatrix(rotationY, Axes.Y) 
-				  * TransformMatrix.CreateRotationMatrix(rotationZ, Axes.Z);
-
-		Points = (this * transform).Points;
 	}
 
 	public void Rotate(float angle, Axes axis)

--- a/Rain.Engine/Scene.cs
+++ b/Rain.Engine/Scene.cs
@@ -218,7 +218,8 @@ public class Scene : IDisposable
 				for (var texture = 0; texture < Models[model].Faces[face].Textures.Length && 
 					 texture < Texture.MaximumBoundTextures; texture++)
 				{
-					Models[model].Faces[face].Textures[texture].Unbind();
+					if (!Models[model].Faces[face].Textures[texture].IsEmpty)
+						Models[model].Faces[face].Textures[texture].Unbind();
 				}
 			}			
 		}

--- a/Rain.Engine/Texturing/TexturedFaceGroup.cs
+++ b/Rain.Engine/Texturing/TexturedFaceGroup.cs
@@ -45,7 +45,7 @@ public struct TexturedFaceGroup
 			textures[face] = texturedFaces[face].Textures;
 		}
 
-		Faces = faces.ToArray();
+		Faces = faces;
 		Textures = new(textures.ToArray());
 	}
 }

--- a/Rain.Game/Program.cs
+++ b/Rain.Game/Program.cs
@@ -12,7 +12,7 @@ class Program
 {
 	static void Main()
 	{
-		var cubeBase = new Rectangle(new(0.5f, 0.5f, -30.0f), 15.0f, 15.0f, new(203, 178, 238));
+		var cubeBase = new Rectangle(new(0.5f, 0.5f, -30.0f), 10.0f, 10.0f, new(203, 178, 238));
 		var textures = new Texture[] { new("interesting.bmp", 0.3f) };
 
 		var texturedBase = new TexturedFace(cubeBase, new Texture[] { new("interesting.bmp", 0.3f) } );
@@ -25,7 +25,8 @@ class Program
 			new(textures)
 		};
 
-		var cube = new Prism(texturedBase, cubeTextures, 15.0f);
+		var cube = new Prism(texturedBase, cubeTextures, 10.0f);
+		cube.LengthZ = 30.0f;
 		var models = new IRenderable[] { cube };
 		var scene = new Scene(models);
 

--- a/Rain.Game/Program.cs
+++ b/Rain.Game/Program.cs
@@ -12,22 +12,25 @@ class Program
 {
 	static void Main()
 	{
-		var cubeBase = new Rectangle(new(0.5f, 0.5f, -30.0f), 10.0f, 10.0f, new(203, 178, 238));
-		var textures = new Texture[] { new("interesting.bmp", 0.3f) };
+		var textures = new Texture[] { new Texture() };
 
-		var texturedBase = new TexturedFace(cubeBase, new Texture[] { new("interesting.bmp", 0.3f) } );
-
-		var cubeTextures = new EfficientTextureGroup[] 
+		var textureGroups = new EfficientTextureGroup[] 
 		{ 
-			new(textures),
-			new(textures),
-			new(textures),
-			new(textures)
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures),
+			new EfficientTextureGroup(textures)
 		};
 
-		var cube = new Prism(texturedBase, cubeTextures, 10.0f);
-		cube.LengthZ = 30.0f;
-		var models = new IRenderable[] { cube };
+		var face = new Rectangle(new Vertex(10.0f, 10.0f, -50.0f), 10.0f, 10.0f);
+
+		face.Rotate(892.0f, Axes.X);
+		face.Rotate(90.0f, Axes.Y);
+
+		var shapeBase = new TexturedFace(face, textures);
+		var prism = new Pyramid(shapeBase, textureGroups, 10.0f);
+
+		var models = new IRenderable[] { prism };
 		var scene = new Scene(models);
 
 		using var game = new GameWindow(new GameOptions


### PR DESCRIPTION
Issues:
- Closes #25

Makes `LengthX`, `LengthY`, and `LengthZ` scale in respect to rotation, prevent a prism from becoming more of a trapezoid type shape after rotating then scaling it. The `RenderableBase.Scale()` method also reflects this change.