### PR TITLE
Use angle struct rather that floats for angles

### DIFF
--- a/Rain.Engine.Tests/Goemetry/AngleTests.cs
+++ b/Rain.Engine.Tests/Goemetry/AngleTests.cs
@@ -20,9 +20,17 @@ public class AngleTests
 		var lineA = new Vertex(aX, aY, aZ);
 		var lineB = new Vertex(bX, bY, bZ);
 
+		var vertexPoint = new Point(new Vertex(vX, vY, vZ));
+		var lineAPoint = new Point(new Vertex(aX, aY, aZ));
+		var lineBPoint = new Point(new Vertex(bX, bY, bZ));
+
 		var angle = Angle.GetAngle(vertex, lineA, lineB);
+		var angleFromPoints = Angle.GetAngle(vertexPoint, lineAPoint, lineBPoint);
 
 		Assert.Equal(expectedAngle, angle.Degrees);
+		Assert.Equal(expectedAngle, angleFromPoints.Degrees);
+		Assert.Equal(angle, angleFromPoints);
+		Assert.Equal(angle.GetHashCode(), angleFromPoints.GetHashCode());
 	}
 
 	[Theory]
@@ -71,8 +79,22 @@ public class AngleTests
 		var aAngle = Angle.FromRadians(a);
 		var bAngle = Angle.FromRadians(b);
 		
-		Assert.Equal(equal, aAngle.Equals(bAngle));
 		Assert.Equal(equal, aAngle == bAngle);
+		Assert.Equal(!equal, aAngle != bAngle);
+
+		// Cast to an object to cover the non-angle Angle.Equals() overload, this is easy to confirm with inlay hints as you
+		// can simply check that the parameter name is "obj".
+		Assert.Equal(equal, aAngle.Equals((object)bAngle));
+
+		Assert.False(aAngle.Equals(null));
+		Assert.False(aAngle.Equals(a));
+		Assert.False(aAngle.Equals(b));
+		Assert.False(aAngle.Equals(equal));
+
+		Assert.False(bAngle.Equals(null));
+		Assert.False(bAngle.Equals(a));
+		Assert.False(bAngle.Equals(b));
+		Assert.False(bAngle.Equals(equal));
 	}
 
 	[Theory]

--- a/Rain.Engine.Tests/Goemetry/AngleTests.cs
+++ b/Rain.Engine.Tests/Goemetry/AngleTests.cs
@@ -29,6 +29,19 @@ public class AngleTests
 	}
 
 	[Theory]
+	[InlineData(0.0, 0.0)]
+	[InlineData(180.0, Math.PI)]
+	[InlineData(90.0, Math.PI / 2)]
+	[InlineData(45.0, Math.PI / 4)]
+	public void FromDegreesAndRadiansTest(double degrees, double radians)
+	{
+		var angleFromDegrees = Angle.FromDegrees(degrees);
+		var angleFromRadians = Angle.FromRadians(radians);
+
+		Assert.Equal(angleFromDegrees, angleFromRadians);
+	}
+
+	[Theory]
 	[InlineData(0.0)]
 	[InlineData(1.0)]
 	[InlineData(45.0)]

--- a/Rain.Engine.Tests/Goemetry/AngleTests.cs
+++ b/Rain.Engine.Tests/Goemetry/AngleTests.cs
@@ -20,12 +20,9 @@ public class AngleTests
 		var lineA = new Vertex(aX, aY, aZ);
 		var lineB = new Vertex(bX, bY, bZ);
 
-		var vertexPoint = new Vertex(vX, vY, vZ);
-		var lineAPoint = new Vertex(aX, aY, aZ);
-		var lineBPoint = new Vertex(bX, bY, bZ);
+		var angle = Angle.GetAngle(vertex, lineA, lineB);
 
-		Assert.Equal(Angle.GetAngle(vertex, lineA, lineB).Degrees, expectedAngle);
-		Assert.Equal(Angle.GetAngle(vertexPoint, lineAPoint, lineBPoint).Degrees, expectedAngle);
+		Assert.Equal(expectedAngle, angle.Degrees);
 	}
 
 	[Theory]
@@ -63,5 +60,70 @@ public class AngleTests
 	public void RadianAndDegreeConversionEqualityTest(double degrees, double radians)
 	{
 		Assert.Equal(Angle.RadiansToDegrees(radians), degrees);
+	}
+
+	[Theory]
+	[InlineData(8.3f, 8.3f, true)]
+	[InlineData(120.0f, 120.0f, true)]
+	[InlineData(120.0f, 67.0f, false)]
+	public void EqualityTest(double a, double b, bool equal)
+	{
+		var aAngle = Angle.FromRadians(a);
+		var bAngle = Angle.FromRadians(b);
+		
+		Assert.Equal(equal, aAngle.Equals(bAngle));
+		Assert.Equal(equal, aAngle == bAngle);
+	}
+
+	[Theory]
+	[InlineData(192.12f, 0.1256f)]
+	[InlineData(1825.0f, 67.9f)]
+	[InlineData(0.0f, 900.0f)]
+	public void AdditionTest(double a, double b)
+	{
+		var aAngle = Angle.FromRadians(a);
+		var bAngle = Angle.FromRadians(b);
+		var expectedAngle = Angle.FromRadians(a + b);
+
+		Assert.Equal(expectedAngle, aAngle + bAngle);
+	}
+
+	[Theory]
+	[InlineData(192.12f, 0.1256f)]
+	[InlineData(1825.0f, 67.9f)]
+	[InlineData(0.0f, 900.0f)]
+	public void SubtractionTest(double a, double b)
+	{
+		var aAngle = Angle.FromRadians(a);
+		var bAngle = Angle.FromRadians(b);
+		var expectedAngle = Angle.FromRadians(a - b);
+
+		Assert.Equal(expectedAngle, aAngle - bAngle);
+	}
+
+	[Theory]
+	[InlineData(192.12f, 0.1256f)]
+	[InlineData(1825.0f, 67.9f)]
+	[InlineData(0.0f, 900.0f)]
+	public void MultiplicationTest(double a, double b)
+	{
+		var aAngle = Angle.FromRadians(a);
+		var bAngle = Angle.FromRadians(b);
+		var expectedAngle = Angle.FromRadians(a * b);
+
+		Assert.Equal(expectedAngle, aAngle * bAngle);
+	}
+
+	[Theory]
+	[InlineData(192.12f, 0.1256f)]
+	[InlineData(1825.0f, 67.9f)]
+	[InlineData(0.0f, 900.0f)]
+	public void DivisionTest(double a, double b)
+	{
+		var aAngle = Angle.FromRadians(a);
+		var bAngle = Angle.FromRadians(b);
+		var expectedAngle = Angle.FromRadians(a / b);
+
+		Assert.Equal(expectedAngle, aAngle / bAngle);
 	}
 }

--- a/Rain.Engine.Tests/Rendering/PrismTests.cs
+++ b/Rain.Engine.Tests/Rendering/PrismTests.cs
@@ -12,7 +12,7 @@ public class PrismTests
 {
 	[Theory]
 	[InlineData(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f)]
-	[InlineData(10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 892.0f, 90.0f)]
+	[InlineData(10.0f, 10.0f, 10.0f, 7.0f, 93.0f, 67.0f, 361.0f, 90.0f)]
 	[InlineData(250.0f, 10.0f, 0.0f, 50.0f, 10.0f, 11.0f, 0.0f, 0.0f)]
 	// Just because this test passes does not mean the Prism has been constructed correctly, the same values should be put in
 	// a project and rendered on an actual window to confirm that the geometry has been rendered correcly.

--- a/Rain.Engine.Tests/Rendering/PrismTests.cs
+++ b/Rain.Engine.Tests/Rendering/PrismTests.cs
@@ -30,8 +30,8 @@ public class PrismTests
 
 		var face = new Rectangle(new Vertex(x, y, z), lengthX, lengthY);
 
-		face.Rotate(angleX, Axes.X);
-		face.Rotate(angleY, Axes.Y);
+		face.Rotate(Angle.FromDegrees(angleX), Axes.X);
+		face.Rotate(Angle.FromDegrees(angleY), Axes.Y);
 
 		var shapeBase = new TexturedFace(face, textures);
 		var prism = new Prism(shapeBase, textureGroups, lengthZ);
@@ -40,8 +40,8 @@ public class PrismTests
 		Assert.Equal(lengthY, prism.LengthY);
 		Assert.Equal(lengthY, prism.LengthY);
 
-		Assert.Equal(angleX, prism.RotationX);
-		Assert.Equal(angleY, prism.RotationY);
+		Assert.Equal(Angle.FromDegrees(angleX), prism.RotationX);
+		Assert.Equal(Angle.FromDegrees(angleY), prism.RotationY);
 	}
 
 	[Theory]
@@ -91,12 +91,12 @@ public class PrismTests
 		var shapeBase = new TexturedFace(face, textures);
 		var prism = new Prism(shapeBase, textureGroups, lengthZ);
 
-		prism.Rotate(angleX, Axes.X);
-		prism.Rotate(angleY, Axes.Y);
-		prism.Rotate(angleZ, Axes.Z);
+		prism.Rotate(Angle.FromDegrees(angleX), Axes.X);
+		prism.Rotate(Angle.FromDegrees(angleY), Axes.Y);
+		prism.Rotate(Angle.FromDegrees(angleZ), Axes.Z);
 
-		Assert.Equal(angleX, prism.RotationX);
-		Assert.Equal(angleY, prism.RotationY);
-		Assert.Equal(angleY, prism.RotationY);
+		Assert.Equal(Angle.FromDegrees(angleX), prism.RotationX);
+		Assert.Equal(Angle.FromDegrees(angleY), prism.RotationY);
+		Assert.Equal(Angle.FromDegrees(angleY), prism.RotationY);
 	}
 }

--- a/Rain.Engine.Tests/Rendering/PyramidTests.cs
+++ b/Rain.Engine.Tests/Rendering/PyramidTests.cs
@@ -30,8 +30,8 @@ public class PyramidTests
 
 		var face = new Rectangle(new Vertex(x, y, z), lengthX, lengthY);
 
-		face.Rotate(angleX, Axes.X);
-		face.Rotate(angleY, Axes.Y);
+		face.Rotate(Angle.FromDegrees(angleX), Axes.X);
+		face.Rotate(Angle.FromDegrees(angleY), Axes.Y);
 
 		var shapeBase = new TexturedFace(face, textures);
 		var pyramid = new Pyramid(shapeBase, textureGroups, lengthZ);
@@ -40,8 +40,8 @@ public class PyramidTests
 		Assert.Equal(lengthY, pyramid.LengthY);
 		Assert.Equal(lengthY, pyramid.LengthY);
 
-		Assert.Equal(angleX, pyramid.RotationX);
-		Assert.Equal(angleY, pyramid.RotationY);
+		Assert.Equal(Angle.FromDegrees(angleX), pyramid.RotationX);
+		Assert.Equal(Angle.FromDegrees(angleY), pyramid.RotationY);
 	}
 
 	[Theory]
@@ -91,12 +91,12 @@ public class PyramidTests
 		var shapeBase = new TexturedFace(face, textures);
 		var pyramid = new Pyramid(shapeBase, textureGroups, lengthZ);
 
-		pyramid.Rotate(angleX, Axes.X);
-		pyramid.Rotate(angleY, Axes.Y);
-		pyramid.Rotate(angleZ, Axes.Z);
+		pyramid.Rotate(Angle.FromDegrees(angleX), Axes.X);
+		pyramid.Rotate(Angle.FromDegrees(angleY), Axes.Y);
+		pyramid.Rotate(Angle.FromDegrees(angleZ), Axes.Z);
 
-		Assert.Equal(angleX, pyramid.RotationX);
-		Assert.Equal(angleY, pyramid.RotationY);
-		Assert.Equal(angleY, pyramid.RotationY);
+		Assert.Equal(Angle.FromDegrees(angleX), pyramid.RotationX);
+		Assert.Equal(Angle.FromDegrees(angleY), pyramid.RotationY);
+		Assert.Equal(Angle.FromDegrees(angleY), pyramid.RotationY);
 	}
 }

--- a/Rain.Engine/GameWindow.cs
+++ b/Rain.Engine/GameWindow.cs
@@ -114,7 +114,7 @@ public class GameWindow : OpenTK.Windowing.Desktop.GameWindow
 		{
 			//model.LengthY -= (float)(1.0f * args.Time);
 			//model.Rotate((float)(2.0f * args.Time), Axes.X);
-			model.Rotate((float)(2.0f * args.Time), Axes.Y);
+			model.Rotate(Angle.FromRadians(2.0f * args.Time), Axes.Y);
 			//model.Translate(0, 0, (float)(-0.1f * args.Time));
 		}
 		

--- a/Rain.Engine/Geometry/Angle.cs
+++ b/Rain.Engine/Geometry/Angle.cs
@@ -45,6 +45,26 @@ public struct Angle
 		=> angle / (PI / 180);
 
 	/// <summary>
+	/// Produces a new <c>Angle</c> from a degree value. 
+	/// </summary>
+	/// 
+	/// <param name="degrees">
+	/// The degree value of the <c>Angle</c>.
+	/// </param>
+	public static Angle FromDegrees(double degrees)
+		=> new() { Degrees = degrees };
+
+	/// <summary>
+	/// Produces a new <c>Angle</c> from a radian value. 
+	/// </summary>
+	/// 
+	/// <param name="radians">
+	/// The radian value of the <c>Angle</c>.
+	/// </param>
+	public static Angle FromRadians(double radians)
+		=> new() { Radians = radians };
+
+	/// <summary>
 	/// Gets an angle from three <c>Vertex</c> instances.
 	/// </summary>
 	/// 
@@ -96,4 +116,19 @@ public struct Angle
 	/// </returns>
 	public static Angle GetAngle(Point angleVertex, Point a, Point b)
 		=> GetAngle(angleVertex.Vertex, a.Vertex, b.Vertex);
+
+	public static Angle operator +(Angle a, Angle b)
+		=> new() { Radians = a.Radians + b.Radians };
+
+	public static Angle operator -(Angle angle)
+		=> new() { Radians = -angle.Radians };
+
+	public static Angle operator -(Angle a, Angle b)
+		=> new() { Radians = a.Radians - b.Radians };
+
+	public static Angle operator *(Angle a, Angle b)
+		=> new() { Radians = a.Radians * b.Radians };
+
+	public static Angle operator /(Angle a, Angle b)
+		=> new() { Radians = a.Radians / b.Radians };
 }

--- a/Rain.Engine/Geometry/Angle.cs
+++ b/Rain.Engine/Geometry/Angle.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022 Evan Overman (https://an-prata.it). Licensed under the MIT License.
 // See LICENSE file in repository root for complete license text.
 
+using System.Diagnostics.CodeAnalysis;
 using static System.Math;
 
 namespace Rain.Engine.Geometry;
@@ -8,7 +9,7 @@ namespace Rain.Engine.Geometry;
 /// <summary>
 /// A struct representing an angle in both Degrees and Radians.
 /// </summary>
-public struct Angle
+public struct Angle : IEquatable<Angle>
 {
 	/// <summary>
 	/// This <c>Angle</c> in Degrees.
@@ -116,6 +117,29 @@ public struct Angle
 	/// </returns>
 	public static Angle GetAngle(Point angleVertex, Point a, Point b)
 		=> GetAngle(angleVertex.Vertex, a.Vertex, b.Vertex);
+	
+	public override int GetHashCode()
+		=> Radians.GetHashCode();
+	
+	public bool Equals(Angle angle)
+		=> Radians == angle.Radians;
+
+	public override bool Equals(object? obj)
+	{
+		if (obj is null)
+			return false;
+	
+		if (obj.GetType() != typeof(Angle))
+			return false;
+
+		return Equals((Angle)obj);
+	}
+
+	public static bool operator ==(Angle a, Angle b)
+		=> a.Equals(b);
+
+	public static bool operator !=(Angle a, Angle b)
+		=> !a.Equals(b);
 
 	public static Angle operator +(Angle a, Angle b)
 		=> new() { Radians = a.Radians + b.Radians };

--- a/Rain.Engine/Geometry/IModel.cs
+++ b/Rain.Engine/Geometry/IModel.cs
@@ -33,17 +33,17 @@ public interface IModel : ISpacial
 	/// <summary>
 	/// The <c>IModel</c>'s counter-clockwise rotation on the X axis.
 	/// </summary>
-	float RotationX { get; set; }
+	Angle RotationX { get; set; }
 
 	/// <summary>
 	/// The <c>IModel</c>'s counter-clockwise rotation on the Y axis.
 	/// </summary>
-	float RotationY { get; set; }
+	Angle RotationY { get; set; }
 
 	/// <summary>
 	/// The <c>IModel</c>'s counter-clockwise rotation on the Z axis.
 	/// </summary>
-	float RotationZ { get; set; }
+	Angle RotationZ { get; set; }
 
 	/// <summary> 
 	/// Gets the <c>IModel</c>'s center point. 

--- a/Rain.Engine/Geometry/ITransformable.cs
+++ b/Rain.Engine/Geometry/ITransformable.cs
@@ -66,7 +66,7 @@ public interface ITransformable
 	/// <param name="axis">
 	/// The axis to rotate on.
 	/// </param>
-	public void Rotate(float angle, Axes axis);
+	public void Rotate(Angle angle, Axes axis);
 
 	/// <summary>
 	/// Rotates the <c>ITransformable</c> about its center.
@@ -87,7 +87,7 @@ public interface ITransformable
 	/// <param name="direction">
 	/// The direction to rotate in.
 	/// </param>
-	public void Rotate(float angle, Axes axis, RotationDirection direction);
+	public void Rotate(Angle angle, Axes axis, RotationDirection direction);
 
 	/// <summary>
 	/// Rotates the <c>ITransformable</c> about the specified <c>Vertex</c>.
@@ -108,7 +108,7 @@ public interface ITransformable
 	/// <param name="vertex">
 	/// The <c>Vertex</c> to rotate around.
 	/// </param>
-	public void Rotate(float angle, Axes axis, Vertex vertex);
+	public void Rotate(Angle angle, Axes axis, Vertex vertex);
 
 	/// <summary>
 	/// Rotates the <c>ITransformable</c> about the specified <c>Vertex</c>.
@@ -133,5 +133,5 @@ public interface ITransformable
 	/// <param name="vertex">
 	/// The <c>Vertex</c> to rotate around.
 	/// </param>
-	public void Rotate(float angle, Axes axis, RotationDirection direction, Vertex vertex);
+	public void Rotate(Angle angle, Axes axis, RotationDirection direction, Vertex vertex);
 }

--- a/Rain.Engine/Geometry/ITwoDimensional.cs
+++ b/Rain.Engine/Geometry/ITwoDimensional.cs
@@ -36,17 +36,17 @@ public interface ITwoDimensional : ISpacial
 	/// <summary>
 	/// The <c>ITwoDimensional</c>'s counter-clockwise rotation on the X axis.
 	/// </summary>
-	float RotationX { get; set; }
+	Angle RotationX { get; set; }
 
 	/// <summary>
 	/// The <c>ITwoDimensional</c>'s counter-clockwise rotation on the Y axis.
 	/// </summary>
-	float RotationY { get; set; }
+	Angle RotationY { get; set; }
 
 	/// <summary>
 	/// The <c>ITwoDimensional</c>'s counter-clockwise rotation on the Z axis.
 	/// </summary>
-	float RotationZ { get; set; }
+	Angle RotationZ { get; set; }
 
 	/// <summary>
 	/// Gets the <c>ITwoDimensional</c>'s center point.
@@ -111,7 +111,7 @@ public interface ITwoDimensional : ISpacial
 	/// <param name="axis">
 	/// The axis to rotate on.
 	/// </param>
-	public void Rotate(float angle, Axes axis);
+	public void Rotate(Angle angle, Axes axis);
 
 	/// <summary>
 	/// Rotates the <c>ITwoDimensional</c> about its center.
@@ -132,7 +132,7 @@ public interface ITwoDimensional : ISpacial
 	/// <param name="direction">
 	/// The direction to rotate in.
 	/// </param>
-	public void Rotate(float angle, Axes axis, RotationDirection direction);
+	public void Rotate(Angle angle, Axes axis, RotationDirection direction);
 
 	/// <summary>
 	/// Rotates the <c>ITwoDimensional</c> about the specified <c>Vertex</c>.
@@ -153,7 +153,7 @@ public interface ITwoDimensional : ISpacial
 	/// <param name="vertex">
 	/// The <c>Vertex</c> to rotate about.
 	/// </param>
-	public void Rotate(float angle, Axes axis, Vertex vertex);
+	public void Rotate(Angle angle, Axes axis, Vertex vertex);
 
 	/// <summary>
 	/// Rotates the <c>ITwoDimensional</c> about the specified <c>Vertex</c>.
@@ -178,5 +178,5 @@ public interface ITwoDimensional : ISpacial
 	/// <param name="vertex">
 	/// The <c>Vertex</c> to rotate about.
 	/// </param>
-	public void Rotate(float angle, Axes axis, RotationDirection direction, Vertex vertex);
+	public void Rotate(Angle angle, Axes axis, RotationDirection direction, Vertex vertex);
 }

--- a/Rain.Engine/Geometry/Rectangle.cs
+++ b/Rain.Engine/Geometry/Rectangle.cs
@@ -22,7 +22,7 @@ public class Rectangle : TwoDimensionalBase
 	/// An array of <c>Point</c>s representing a rectangle.
 	/// </param>
 	public Rectangle(Point[] points) :
-		base((float)points[0].GetDistanceBetween(points[3]), (float)points[0].GetDistanceBetween(points[1]), 0.0f, 0.0f, 0.0f)
+		base((float)points[0].GetDistanceBetween(points[3]), (float)points[0].GetDistanceBetween(points[1]))
 	{
 		if (points.Length != 4)
 			throw new Exception($"{nameof(points)} is not length 4 (Given length: {points.Length}).");
@@ -53,17 +53,17 @@ public class Rectangle : TwoDimensionalBase
 	/// The <c>Rectangle</c>'s height.
 	/// </param>
 	public Rectangle(Vertex location, float width, float height) :
-		base(width, height, 0.0f, 0.0f, 0.0f)
+		base(width, height)
 	{
 		var halfWidth = width / 2;
 		var halfHeight = height / 2;
 
 		Points = new Point[]
 		{
-			new(new(location.X - halfWidth, location.Y - halfHeight, location.Z), new(255, 255, 255), new(1.0f, 0.0f)),
-			new(new(location.X + halfWidth, location.Y - halfHeight, location.Z), new(255, 255, 255), new(0.0f, 0.0f)),
-			new(new(location.X + halfWidth, location.Y + halfHeight, location.Z), new(255, 255, 255), new(0.0f, 1.0f)),
-			new(new(location.X - halfWidth, location.Y + halfHeight, location.Z), new(255, 255, 255), new(1.0f, 1.0f))
+			new(new(location.X - halfWidth, location.Y - halfHeight, location.Z), new TextureCoordinate(1.0f, 0.0f)),
+			new(new(location.X + halfWidth, location.Y - halfHeight, location.Z),  new TextureCoordinate(0.0f, 0.0f)),
+			new(new(location.X + halfWidth, location.Y + halfHeight, location.Z),  new TextureCoordinate(0.0f, 1.0f)),
+			new(new(location.X - halfWidth, location.Y + halfHeight, location.Z),  new TextureCoordinate(1.0f, 1.0f))
 		};
 	}
 
@@ -87,7 +87,7 @@ public class Rectangle : TwoDimensionalBase
 	/// The <c>Rectangle</c>'s color.
 	/// </param>
 	public Rectangle(Vertex location, float width, float height, Color color) :
-		base(width, height, 0.0f, 0.0f, 0.0f)
+		base(width, height)
 	{
 		var halfWidth = width / 2;
 		var halfHeight = height / 2;

--- a/Rain.Engine/Geometry/TransformMatrix.cs
+++ b/Rain.Engine/Geometry/TransformMatrix.cs
@@ -157,7 +157,7 @@ public struct TransformMatrix
 
 	/// <summary>
 	/// Creates a new <c>TransformMatrix</c> that, when multiplied with a shape's <c>Vertex</c> objects, will rotate the shape
-	/// about its center.
+	/// about the origin.
 	/// </summary>
 	/// 
 	/// <param name="angle">
@@ -206,6 +206,65 @@ public struct TransformMatrix
 
 		return new TransformMatrix(matrix, TransformType.Rotation);
 	}
+
+	/// <summary>
+	/// Creates a new <c>TransformMatrix</c> that, when multiplied with a shape's <c>Vertex</c> objects, will rotate the shape
+	/// about the origin.
+	/// </summary>
+	/// 
+	/// <param name="angle">
+	/// The <c>Angle</c> to rotate by.
+	/// </param>
+	/// 
+	/// <param name="axis">
+	/// The axis to rotate around.
+	/// </param>
+	public static TransformMatrix CreateRotationMatrix(Angle angle, Axes axis)
+		=> CreateRotationMatrix((float)angle.Radians, axis);
+	
+	/// <summary>
+	/// Creates a new <c>TransformMatrix</c> that, when multiplied with a shape's <c>Vertex</c> objects, will rotate the shape
+	/// about the origin.
+	/// </summary>
+	/// 
+	/// <param name="x">
+	/// The angle to rotate around the x axis.
+	/// </param>
+	/// 
+	/// <param name="y">
+	/// The angle to rotate around the y axis.
+	/// </param>
+	/// 
+	/// <param name="z">
+	/// The angle to rotate around the z axis.
+	/// </param>
+	public static TransformMatrix CreateRotationMatrix(float x, float y, float z)
+	{
+		var xRotation = CreateRotationMatrix(x, Axes.X);
+		var yRotation = CreateRotationMatrix(y, Axes.Y);
+		var zRotation = CreateRotationMatrix(z, Axes.Z);
+
+		return zRotation * yRotation * xRotation;
+	}
+	
+	/// <summary>
+	/// Creates a new <c>TransformMatrix</c> that, when multiplied with a shape's <c>Vertex</c> objects, will rotate the shape
+	/// about the origin.
+	/// </summary>
+	/// 
+	/// <param name="x">
+	/// The angle to rotate around the x axis.
+	/// </param>
+	/// 
+	/// <param name="y">
+	/// The angle to rotate around the y axis.
+	/// </param>
+	/// 
+	/// <param name="z">
+	/// The angle to rotate around the z axis.
+	/// </param>
+	public static TransformMatrix CreateRotationMatrix(Angle x, Angle y, Angle z)
+		=> CreateRotationMatrix((float)x.Radians, (float)y.Radians, (float)z.Radians);
 
 	/// <summary>
 	/// Creates a new <c>TransformMatrix</c> that, when multiplied with all of a <c>Scene</c>'s points, will make objects

--- a/Rain.Engine/Geometry/Triangle.cs
+++ b/Rain.Engine/Geometry/Triangle.cs
@@ -22,7 +22,7 @@ public class Triangle : TwoDimensionalBase
 	/// An array of <c>Points</c>s representing a triangle.
 	/// </param>
 	public Triangle(Point[] points) :
-		base((float)points[0].GetDistanceBetween(points[1]), (float)points[0].Vertex.GetMidPoint(points[1].Vertex).GetDistanceBetween(points[2].Vertex), 0.0f, 0.0f, 0.0f)
+		base((float)points[0].GetDistanceBetween(points[1]), (float)points[0].Vertex.GetMidPoint(points[1].Vertex).GetDistanceBetween(points[2].Vertex))
 	{
 		if (points.Length != 3)
 			throw new Exception($"{nameof(points)} is not length 3 (Given length: {points.Length}).");
@@ -46,13 +46,13 @@ public class Triangle : TwoDimensionalBase
 	/// The <c>Triangle</c>'s height.
 	/// </param>
 	public Triangle(Vertex location, float width, float height) :
-		base(width, height, 0.0f, 0.0f, 0.0f)
+		base(width, height)
 	{
 		Points = new Point[]
 		{
-			new(location, new(255, 255, 255), new(0.0f, 0.0f)),
-			new(new(location.X + width, location.Y, location.Z), new(255, 255, 255), new(1.0f, 0.0f)),
-			new(new(location.X, location.Y + height, location.Z), new(255, 255, 255), new(0.0f, 1.0f)),
+			new(location, new TextureCoordinate(0.0f, 0.0f)),
+			new(new(location.X + width, location.Y, location.Z), new TextureCoordinate(1.0f, 0.0f)),
+			new(new(location.X, location.Y + height, location.Z), new TextureCoordinate(0.0f, 1.0f)),
 		};
 	}
 
@@ -76,7 +76,7 @@ public class Triangle : TwoDimensionalBase
 	/// The <c>Triangle</c>'s color.
 	/// </param>
 	public Triangle(Vertex location, float width, float height, Color color) :
-		base(width, height, 0.0f, 0.0f, 0.0f)
+		base(width, height)
 	{
 		Points = new Point[]
 		{

--- a/Rain.Engine/Geometry/TwoDimensionalBase.cs
+++ b/Rain.Engine/Geometry/TwoDimensionalBase.cs
@@ -9,11 +9,11 @@ public abstract class TwoDimensionalBase : ITwoDimensional, ISpacial
 
 	private float height = 0.0f;
 
-	private float rotationX = 0.0f;
+	private Angle rotationX;
 
-	private float rotationY = 0.0f;
+	private Angle rotationY;
 
-	private float rotationZ = 0.0f;
+	private Angle rotationZ;
 
 	public abstract uint[] Elements { get; }
 
@@ -39,25 +39,35 @@ public abstract class TwoDimensionalBase : ITwoDimensional, ISpacial
 		set => Scale(1, value / height); 
 	}
 
-	public float RotationX 
+	public Angle RotationX 
 	{ 
 		get => rotationX; 
 		set => Rotate(value / rotationX, Axes.X); 
 	}
 
-	public float RotationY
+	public Angle RotationY
 	{ 
 		get => rotationY; 
 		set => Rotate(value / rotationY, Axes.Y); 
 	}
 
-	public float RotationZ 
+	public Angle RotationZ 
 	{ 
 		get => rotationZ; 
 		set => Rotate(value / rotationZ, Axes.Z); 
 	}
 
-	public TwoDimensionalBase(float width, float height, float rotationX, float rotationY, float rotationZ)
+	public TwoDimensionalBase(float width, float height)
+	{
+		this.width = width;
+		this.height = height;
+
+		rotationX = new() { Radians = 0.0f };
+		rotationY = new() { Radians = 0.0f };
+		rotationZ = new() { Radians = 0.0f };
+	}
+
+	public TwoDimensionalBase(float width, float height, Angle rotationX, Angle rotationY, Angle rotationZ)
 	{
 		this.width = width;
 		this.height = height;
@@ -111,10 +121,10 @@ public abstract class TwoDimensionalBase : ITwoDimensional, ISpacial
 		height *= y;
 	}
 
-	public void Rotate(float angle, Axes axis)
+	public void Rotate(Angle angle, Axes axis)
 		=> Rotate(angle, axis, Location);
 
-	public void Rotate(float angle, Axes axis, RotationDirection direction)
+	public void Rotate(Angle angle, Axes axis, RotationDirection direction)
 	{
 		if (direction == RotationDirection.CounterClockwise)
 			Rotate(angle, axis, Location);
@@ -122,7 +132,7 @@ public abstract class TwoDimensionalBase : ITwoDimensional, ISpacial
 			Rotate(-angle, axis, Location);
 	}
 
-	public void Rotate(float angle, Axes axis, Vertex vertex)
+	public void Rotate(Angle angle, Axes axis, Vertex vertex)
 	{
 		var transform = TransformMatrix.CreateTranslationMatrix(vertex);
 		transform *= TransformMatrix.CreateRotationMatrix(angle, axis);
@@ -146,7 +156,7 @@ public abstract class TwoDimensionalBase : ITwoDimensional, ISpacial
 		}
 	}
 
-	public void Rotate(float angle, Axes axis, RotationDirection direction, Vertex vertex)
+	public void Rotate(Angle angle, Axes axis, RotationDirection direction, Vertex vertex)
 	{
 		if (direction == RotationDirection.CounterClockwise)
 			Rotate(angle, axis, vertex);

--- a/Rain.Engine/Rendering/RenderableBase.cs
+++ b/Rain.Engine/Rendering/RenderableBase.cs
@@ -18,11 +18,11 @@ public abstract class RenderableBase : IRenderable, IEquatable<RenderableBase>
 
 	private float lengthZ = 1.0f;
 
-	private float rotationX = 0.0f;
+	private Angle rotationX;
 
-	private float rotationY = 0.0f;
+	private Angle rotationY;
 
-	private float rotationZ = 0.0f;
+	private Angle rotationZ;
 
 	/// <summary>
 	/// The <c>TexturedFace</c> objects this object is composed of.
@@ -82,25 +82,36 @@ public abstract class RenderableBase : IRenderable, IEquatable<RenderableBase>
 		set => Scale(1, 1, value / lengthZ); 
 	}
 
-	public float RotationX 
+	public Angle RotationX 
 	{ 
 		get => rotationX; 
 		set => Rotate(value / rotationX, Axes.X); 
 	}
 
-	public float RotationY
+	public Angle RotationY
 	{ 
 		get => rotationY; 
 		set => Rotate(value / rotationY, Axes.Y); 
 	}
 
-	public float RotationZ 
+	public Angle RotationZ 
 	{ 
 		get => rotationZ; 
 		set => Rotate(value / rotationZ, Axes.Z); 
 	}
 
-	public RenderableBase(float lengthX, float lengthY, float lengthZ, float rotationX, float rotationY, float rotationZ)
+	public RenderableBase(float lengthX, float lengthY, float lengthZ)
+	{
+		this.lengthX = lengthX;
+		this.lengthY = lengthY;
+		this.lengthZ = lengthZ;
+
+		rotationX = new() { Radians = 0.0f };
+		rotationY = new() { Radians = 0.0f };
+		rotationZ = new() { Radians = 0.0f };
+	}
+
+	public RenderableBase(float lengthX, float lengthY, float lengthZ, Angle rotationX, Angle rotationY, Angle rotationZ)
 	{
 		this.lengthX = lengthX;
 		this.lengthY = lengthY;
@@ -199,10 +210,10 @@ public abstract class RenderableBase : IRenderable, IEquatable<RenderableBase>
 		lengthZ *= z;
 	}
 
-	public void Rotate(float angle, Axes axis)
+	public void Rotate(Angle angle, Axes axis)
 		=> Rotate(angle, axis, GetCenterVertex());
 
-	public void Rotate(float angle, Axes axis, RotationDirection direction)
+	public void Rotate(Angle angle, Axes axis, RotationDirection direction)
 	{
 		if (direction == RotationDirection.CounterClockwise)
 			Rotate(angle, axis, GetCenterVertex());
@@ -210,7 +221,7 @@ public abstract class RenderableBase : IRenderable, IEquatable<RenderableBase>
 			Rotate(-angle, axis, GetCenterVertex());
 	}
 
-	public void Rotate(float angle, Axes axis, Vertex vertex)
+	public void Rotate(Angle angle, Axes axis, Vertex vertex)
 	{
 		var transform = TransformMatrix.CreateTranslationMatrix(vertex);
 		transform *= TransformMatrix.CreateRotationMatrix(angle, axis);
@@ -234,7 +245,7 @@ public abstract class RenderableBase : IRenderable, IEquatable<RenderableBase>
 		}
 	}
 
-	public void Rotate(float angle, Axes axis, RotationDirection direction, Vertex vertex)
+	public void Rotate(Angle angle, Axes axis, RotationDirection direction, Vertex vertex)
 	{
 		if (direction == RotationDirection.CounterClockwise)
 			Rotate(angle, axis, vertex);

--- a/Rain.Game/Program.cs
+++ b/Rain.Game/Program.cs
@@ -24,8 +24,8 @@ class Program
 
 		var face = new Rectangle(new Vertex(10.0f, 10.0f, -50.0f), 10.0f, 10.0f);
 
-		face.Rotate(892.0f, Axes.X);
-		face.Rotate(90.0f, Axes.Y);
+		face.Rotate(Angle.FromDegrees(892.0f), Axes.X);
+		face.Rotate(Angle.FromDegrees(90.0f), Axes.Y);
 
 		var shapeBase = new TexturedFace(face, textures);
 		var prism = new Pyramid(shapeBase, textureGroups, 10.0f);


### PR DESCRIPTION
Replaces all instances of a class or struct using a `float` for angle measures with the `Angle` struct in order to eliminate guessing about whether that float represents an angle measure in Radians or Degrees.