### PR TITLE
Fixes the non-rotating rectangular face in a square pyramid

### DIFF
--- a/Rain.Engine/Geometry/Rectangle.cs
+++ b/Rain.Engine/Geometry/Rectangle.cs
@@ -105,9 +105,7 @@ public class Rectangle : TwoDimensionalBase
 		base(rectangle.Width, rectangle.Height, rectangle.RotationX, rectangle.RotationY, rectangle.RotationZ)
 	{
 		Points = new Point[rectangle.Points.Length];
-		
-		for (var point = 0; point < Points.Length; point++)
-			rectangle.Points[point].CopyTo(out Points[point]);
+		rectangle.Points.CopyTo(Points, 0);
 	}
 
 	public override void CopyTo(out TwoDimensionalBase twoDimensional)

--- a/Rain.Engine/Geometry/Triangle.cs
+++ b/Rain.Engine/Geometry/Triangle.cs
@@ -27,7 +27,8 @@ public class Triangle : TwoDimensionalBase
 		if (points.Length != 3)
 			throw new Exception($"{nameof(points)} is not length 3 (Given length: {points.Length}).");
 
-		Points = points;
+		Points = new Point[points.Length];
+		points.CopyTo(Points, 0);
 	}
 
 	/// <summary>


### PR DESCRIPTION
This would happen elsewhere when setting a `Rectangle`'s points, the `Rectangle` would not transform with other points.