### PR TITLE
Remove "Matrix" suffix in static methods for creating matrices

### DIFF
--- a/Rain.Engine.Tests/Goemetry/TransformMatrixTests.cs
+++ b/Rain.Engine.Tests/Goemetry/TransformMatrixTests.cs
@@ -59,7 +59,7 @@ public class TransformMatrixTests
 								float eX,   float eY,   float eZ)
 	{
 		var vertex = new Vertex(x, y, z);
-		var translation = TransformMatrix.CreateTranslationMatrix(tX, tY, tZ);
+		var translation = TransformMatrix.CreateTranslation(tX, tY, tZ);
 		Assert.True(translation * vertex == new Vertex(eX, eY, eZ));
 	}
 
@@ -81,7 +81,7 @@ public class TransformMatrixTests
 							 float eX,  float eY,   float eZ)
 	{
 		var vertex = new Vertex(x, y, z);
-		var transformMatrix = TransformMatrix.CreateRotationMatrix(angle, axis);
+		var transformMatrix = TransformMatrix.CreateRotation(angle, axis);
 		Assert.True(vertex * transformMatrix == new Vertex(eX, eY, eZ));
 	}
 }

--- a/Rain.Engine/Geometry/TransformMatrix.cs
+++ b/Rain.Engine/Geometry/TransformMatrix.cs
@@ -9,6 +9,8 @@ namespace Rain.Engine.Geometry;
 
 public struct TransformMatrix
 {
+	private readonly float[,] matrix;
+
 	public float this[int index0, int index1]
 	{
 		get => matrix[index0, index1];
@@ -24,8 +26,6 @@ public struct TransformMatrix
 	/// The <c>TransformType</c> associated with this <c>TransformMatrix</c>.
 	/// </summary>
 	public TransformType TransformType { get; private set; }
-
-	private float[,] matrix;
 
 	/// <summary> 
 	/// Creates a new TransformMatrix representing the Identity Matrix. 
@@ -101,7 +101,7 @@ public struct TransformMatrix
 	/// <param name="zScale">
 	/// The scale factor to be applied to the <c>Vertex</c>'s Z value.
 	/// </param>
-	public static TransformMatrix CreateScaleMatrix(float xScale, float yScale, float zScale)
+	public static TransformMatrix CreateScale(float xScale, float yScale, float zScale)
 	{
 		var matrix = new float[,]
 		{
@@ -130,7 +130,7 @@ public struct TransformMatrix
 	/// <param name="zTranslation">
 	/// The distance to move along the Z axis.
 	/// </param>
-	public static TransformMatrix CreateTranslationMatrix(float xTranslation, float yTranslation, float zTranslation)
+	public static TransformMatrix CreateTranslation(float xTranslation, float yTranslation, float zTranslation)
 	{
 		var matrix = new float[,]
 		{
@@ -152,8 +152,8 @@ public struct TransformMatrix
 	/// A <c>Vertex</c> who's X, Y, and Z values will be used as distances to translate any multiplied vertex by on their
 	/// respective axis.
 	/// </param>
-	public static TransformMatrix CreateTranslationMatrix(Vertex translation)
-		=> CreateTranslationMatrix(translation.X, translation.Y, translation.Z);
+	public static TransformMatrix CreateTranslation(Vertex translation)
+		=> CreateTranslation(translation.X, translation.Y, translation.Z);
 
 	/// <summary>
 	/// Creates a new <c>TransformMatrix</c> that, when multiplied with a shape's <c>Vertex</c> objects, will rotate the shape
@@ -161,17 +161,17 @@ public struct TransformMatrix
 	/// </summary>
 	/// 
 	/// <param name="angle">
-	/// The angle measer to rotate by.
+	/// The angle measer to rotate by in radians.
 	/// </param>
 	/// 
 	/// <param name="axis">
 	/// The axis to rotate around.
 	/// </param>
-	public static TransformMatrix CreateRotationMatrix(float angle, Axes axis)
+	public static TransformMatrix CreateRotation(float angle, Axes axis)
 	{
 		var matrix = new float[Size, Size];
-		var sinTheta = (float)Sin(Angle.DegreesToRadians(angle));
-		var cosTheta = (float)Cos(Angle.DegreesToRadians(angle));
+		var sinTheta = (float)Sin(angle);
+		var cosTheta = (float)Cos(angle);
 
 		if (axis == Axes.X)
 		{
@@ -219,8 +219,8 @@ public struct TransformMatrix
 	/// <param name="axis">
 	/// The axis to rotate around.
 	/// </param>
-	public static TransformMatrix CreateRotationMatrix(Angle angle, Axes axis)
-		=> CreateRotationMatrix((float)angle.Radians, axis);
+	public static TransformMatrix CreateRotation(Angle angle, Axes axis)
+		=> CreateRotation((float)angle.Radians, axis);
 	
 	/// <summary>
 	/// Creates a new <c>TransformMatrix</c> that, when multiplied with a shape's <c>Vertex</c> objects, will rotate the shape
@@ -238,11 +238,11 @@ public struct TransformMatrix
 	/// <param name="z">
 	/// The angle to rotate around the z axis.
 	/// </param>
-	public static TransformMatrix CreateRotationMatrix(float x, float y, float z)
+	public static TransformMatrix CreateRotation(float x, float y, float z)
 	{
-		var xRotation = CreateRotationMatrix(x, Axes.X);
-		var yRotation = CreateRotationMatrix(y, Axes.Y);
-		var zRotation = CreateRotationMatrix(z, Axes.Z);
+		var xRotation = CreateRotation(x, Axes.X);
+		var yRotation = CreateRotation(y, Axes.Y);
+		var zRotation = CreateRotation(z, Axes.Z);
 
 		return zRotation * yRotation * xRotation;
 	}
@@ -263,8 +263,8 @@ public struct TransformMatrix
 	/// <param name="z">
 	/// The angle to rotate around the z axis.
 	/// </param>
-	public static TransformMatrix CreateRotationMatrix(Angle x, Angle y, Angle z)
-		=> CreateRotationMatrix((float)x.Radians, (float)y.Radians, (float)z.Radians);
+	public static TransformMatrix CreateRotation(Angle x, Angle y, Angle z)
+		=> CreateRotation((float)x.Radians, (float)y.Radians, (float)z.Radians);
 
 	/// <summary>
 	/// Creates a new <c>TransformMatrix</c> that, when multiplied with all of a <c>Scene</c>'s points, will make objects
@@ -272,11 +272,11 @@ public struct TransformMatrix
 	/// </summary>
 	/// 
 	/// <param name="fovX">
-	/// The up-down feild of veiw.
+	/// The left-right feild of veiw.
 	/// </param>
 	/// 
 	/// <param name="fovY">
-	/// The left-right feild of veiw.
+	/// The up-down feild of veiw.
 	/// </param>
 	/// 
 	/// <param name="nearClip">
@@ -286,7 +286,7 @@ public struct TransformMatrix
 	/// <param name="farClip">
 	/// The maximum distance at which objects will be drawn.
 	/// </param>
-	public static TransformMatrix CreatePerspectiveProjectionMatrix(float fovX, float fovY, float nearClip, float farClip)
+	public static TransformMatrix CreatePerspectiveProjection(float fovX, float fovY, float nearClip, float farClip)
 	{
 		var upperBound = nearClip * Tan(0.5f * fovY);
 		var lowerBound = -upperBound;

--- a/Rain.Engine/Geometry/TwoDimensional/TwoDimensionalBase.cs
+++ b/Rain.Engine/Geometry/TwoDimensional/TwoDimensionalBase.cs
@@ -94,26 +94,26 @@ public abstract class TwoDimensionalBase : ITwoDimensional, ISpacial
 	public abstract void CopyTo(out TwoDimensionalBase twoDimensional);
 
 	public void Translate(float x, float y, float z)
-		=> Points = (this * TransformMatrix.CreateTranslationMatrix(x, y, z)).Points;
+		=> Points = (this * TransformMatrix.CreateTranslation(x, y, z)).Points;
 
 	public void Translate(Vertex vertex)
 		=> Translate(vertex.X, vertex.Y, vertex.Z);
 
 	public void Scale(float x = 1, float y = 1)
 	{
-		var transform = TransformMatrix.CreateTranslationMatrix(Location);
+		var transform = TransformMatrix.CreateTranslation(Location);
 
-		transform *= TransformMatrix.CreateRotationMatrix(-rotationX, Axes.X);
-		transform *= TransformMatrix.CreateRotationMatrix(-rotationY, Axes.Y);
-		transform *= TransformMatrix.CreateRotationMatrix(-rotationZ, Axes.Z);
+		transform *= TransformMatrix.CreateRotation(-rotationX, Axes.X);
+		transform *= TransformMatrix.CreateRotation(-rotationY, Axes.Y);
+		transform *= TransformMatrix.CreateRotation(-rotationZ, Axes.Z);
 
-		transform *= TransformMatrix.CreateScaleMatrix(x, y, 1);
+		transform *= TransformMatrix.CreateScale(x, y, 1);
 
-		transform *= TransformMatrix.CreateRotationMatrix(rotationX, Axes.X);
-		transform *= TransformMatrix.CreateRotationMatrix(rotationY, Axes.Y);
-		transform *= TransformMatrix.CreateRotationMatrix(rotationZ, Axes.Z);
+		transform *= TransformMatrix.CreateRotation(rotationX, Axes.X);
+		transform *= TransformMatrix.CreateRotation(rotationY, Axes.Y);
+		transform *= TransformMatrix.CreateRotation(rotationZ, Axes.Z);
 		
-		transform *= TransformMatrix.CreateTranslationMatrix(-Location);
+		transform *= TransformMatrix.CreateTranslation(-Location);
 
 		Points = (this * transform).Points;
 
@@ -134,9 +134,9 @@ public abstract class TwoDimensionalBase : ITwoDimensional, ISpacial
 
 	public void Rotate(Angle angle, Axes axis, Vertex vertex)
 	{
-		var transform = TransformMatrix.CreateTranslationMatrix(vertex);
-		transform *= TransformMatrix.CreateRotationMatrix(angle, axis);
-		transform *= TransformMatrix.CreateTranslationMatrix(-vertex);
+		var transform = TransformMatrix.CreateTranslation(vertex);
+		transform *= TransformMatrix.CreateRotation(angle, axis);
+		transform *= TransformMatrix.CreateTranslation(-vertex);
 
 		Points = (this * transform).Points;
 

--- a/Rain.Engine/Rendering/Pyramid.cs
+++ b/Rain.Engine/Rendering/Pyramid.cs
@@ -33,7 +33,7 @@ public class Pyramid : RenderableBase
 		shapeBase.Rotate(-shapeBase.RotationY, Axes.Y);
 		shapeBase.Rotate(-shapeBase.RotationZ, Axes.Z);
 
-		var translateUp = TransformMatrix.CreateTranslationMatrix(0, 0, lengthZ);
+		var translateUp = TransformMatrix.CreateTranslation(0, 0, lengthZ);
 		var tip = new Point(shapeBase.Location * translateUp, shapeBase.Points[0].Color, TextureCoordinate.TopMiddle); 
 
 		var faces = new Face[1 + shapeBase.Sides.Length];
@@ -93,7 +93,7 @@ public class Pyramid : RenderableBase
 		shapeBase.Rotate(-shapeBase.RotationY, Axes.Y);
 		shapeBase.Rotate(-shapeBase.RotationZ, Axes.Z);
 
-		var translateUp = TransformMatrix.CreateTranslationMatrix(0, 0, lengthZ);
+		var translateUp = TransformMatrix.CreateTranslation(0, 0, lengthZ);
 		var tip = new Point(shapeBase.Location * translateUp, color, TextureCoordinate.TopLeft); 
 
 		var faces = new Face[1 + shapeBase.Sides.Length];
@@ -155,7 +155,7 @@ public class Pyramid : RenderableBase
 		shapeBase.Rotate(-shapeBase.RotationY, Axes.Y);
 		shapeBase.Rotate(-shapeBase.RotationZ, Axes.Z);
 
-		var translateUp = TransformMatrix.CreateTranslationMatrix(0, 0, lengthZ);
+		var translateUp = TransformMatrix.CreateTranslation(0, 0, lengthZ);
 		var tip = new Point(shapeBase.Location * translateUp, shapeBase.Points[0].Color, new(0.5f, 1.0f)); 
 
 		var faces = new TexturedFace[1 + shapeBase.Sides.Length];

--- a/Rain.Engine/Rendering/RenderableBase.cs
+++ b/Rain.Engine/Rendering/RenderableBase.cs
@@ -207,26 +207,26 @@ public abstract class RenderableBase : IRenderable, IEquatable<RenderableBase>
 	}
 
 	public void Translate(float x, float y, float z)
-		=> Points = (this * TransformMatrix.CreateTranslationMatrix(x, y, z)).Points;
+		=> Points = (this * TransformMatrix.CreateTranslation(x, y, z)).Points;
 
 	public void Translate(Vertex vertex)
 		=> Translate(vertex.X, vertex.Y, vertex.Z);
 
 	public void Scale(float x = 1, float y = 1, float z = 1)
 	{
-		var transform = TransformMatrix.CreateTranslationMatrix(Location);
+		var transform = TransformMatrix.CreateTranslation(Location);
 
-		transform *= TransformMatrix.CreateRotationMatrix(-rotationX, Axes.X);
-		transform *= TransformMatrix.CreateRotationMatrix(-rotationY, Axes.Y);
-		transform *= TransformMatrix.CreateRotationMatrix(-rotationZ, Axes.Z);
+		transform *= TransformMatrix.CreateRotation(-rotationX, Axes.X);
+		transform *= TransformMatrix.CreateRotation(-rotationY, Axes.Y);
+		transform *= TransformMatrix.CreateRotation(-rotationZ, Axes.Z);
 
-		transform *= TransformMatrix.CreateScaleMatrix(x, y, z);
+		transform *= TransformMatrix.CreateScale(x, y, z);
 
-		transform *= TransformMatrix.CreateRotationMatrix(rotationX, Axes.X);
-		transform *= TransformMatrix.CreateRotationMatrix(rotationY, Axes.Y);
-		transform *= TransformMatrix.CreateRotationMatrix(rotationZ, Axes.Z);
+		transform *= TransformMatrix.CreateRotation(rotationX, Axes.X);
+		transform *= TransformMatrix.CreateRotation(rotationY, Axes.Y);
+		transform *= TransformMatrix.CreateRotation(rotationZ, Axes.Z);
 		
-		transform *= TransformMatrix.CreateTranslationMatrix(-Location);
+		transform *= TransformMatrix.CreateTranslation(-Location);
 
 		Points = (this * transform).Points;
 
@@ -248,9 +248,9 @@ public abstract class RenderableBase : IRenderable, IEquatable<RenderableBase>
 
 	public void Rotate(Angle angle, Axes axis, Vertex vertex)
 	{
-		var transform = TransformMatrix.CreateTranslationMatrix(vertex);
-		transform *= TransformMatrix.CreateRotationMatrix(angle, axis);
-		transform *= TransformMatrix.CreateTranslationMatrix(-vertex);
+		var transform = TransformMatrix.CreateTranslation(vertex);
+		transform *= TransformMatrix.CreateRotation(angle, axis);
+		transform *= TransformMatrix.CreateTranslation(-vertex);
 
 		Points = (this * transform).Points;
 


### PR DESCRIPTION
Simply makes names of methods found in the `TransformMatrix` class less verbose by removing redundant `Matrix` suffix.